### PR TITLE
Standardize Timezone Handling To UTC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,11 @@ ARG GIT_COMMIT_HASH
 ENV RELEASE_TAG=${RELEASE_TAG}
 ENV GIT_COMMIT_HASH=${GIT_COMMIT_HASH}
 
+# Persists TZ=UTC effect after container build and into container run
+# Ensures dates/times are consistently formated as UTC
+# Conversion to local time should happen in the UI
+ENV TZ=UTC
+
 ENV NODE_ENV=production
 USER node
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,6 +1,7 @@
 version: "3"
 
 x-default-environment: &default-environment
+  TZ: "UTC"
   NODE_ENV: development
   DB_HOST: db
   DB_USER: sa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,9 @@ services:
     image: mcr.microsoft.com/mssql/server:2022-latest
     user: root
     environment:
+      TZ: "UTC"
       # default user is `sa`
       MSSQL_SA_PASSWORD: "${DB_PASS}"
-      TZ: "America/Whitehorse"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/9

Relates to:
- https://github.com/icefoganalytics/elcc-data-management/pull/73/files

# Context

Using the pattern developed in the elcc-data-management project, make sure that all app components use UTC by default.
Time related data should only be converted to the User's timezone at the last minute, when displaying the data.

# Implementation

:clock3: Enforce UTC in back-end in development and production modes.

# Testing Instructions

1. Boot the app via `dev up`
2. Check the app loads at http://localhost:8080
