### PR TITLE
Fix tsconfig.json Error Around `express-unless`

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -26,7 +26,6 @@
         "@types/cls-hooked": "^4.3.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
-        "@types/express-jwt": "^6.0.4",
         "@types/lodash": "^4.14.202",
         "@typescript-eslint/eslint-plugin": "^6.18.0",
         "@typescript-eslint/parser": "^6.18.0",
@@ -601,16 +600,6 @@
         "@types/serve-static": "*"
       }
     },
-    "node_modules/@types/express-jwt": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/express-jwt/-/express-jwt-6.0.4.tgz",
-      "integrity": "sha512-I53KRQ9D0eTA6hVCN9S73iOeprKS3JNWK+Cp2mDPB6uOIkTVpkgSkX394kHQzb5cd0U02I0adRmsMxHk+zX8tA==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*",
-        "@types/express-unless": "*"
-      }
-    },
     "node_modules/@types/express-serve-static-core": {
       "version": "4.17.41",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
@@ -620,16 +609,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express-unless": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-2.0.1.tgz",
-      "integrity": "sha512-PJLiNw03EjkWDkQbhNjIXXDLObC3eMQhFASDV+WakFbT8eL7YdjlbV6MXd3Av5Lejq499d6pFuV1jyK+EHyG3Q==",
-      "deprecated": "This is a stub types definition. express-unless provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "express-unless": "*"
       }
     },
     "node_modules/@types/http-errors": {

--- a/api/package.json
+++ b/api/package.json
@@ -33,7 +33,6 @@
     "@types/cls-hooked": "^4.3.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
-    "@types/express-jwt": "^6.0.4",
     "@types/lodash": "^4.14.202",
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "@typescript-eslint/parser": "^6.18.0",

--- a/api/src/middlewares/jwt-middleware.ts
+++ b/api/src/middlewares/jwt-middleware.ts
@@ -1,0 +1,20 @@
+import { expressjwt as jwt } from "express-jwt"
+import jwksRsa, { type GetVerificationKey } from "jwks-rsa"
+
+import { AUTH0_DOMAIN, AUTH0_AUDIENCE } from "@/config"
+
+console.log("AUTH0_DOMAIN", `${AUTH0_DOMAIN}/.well-known/jwks.json`)
+
+export default jwt({
+  secret: jwksRsa.expressJwtSecret({
+    cache: true,
+    rateLimit: true,
+    jwksRequestsPerMinute: 5,
+    jwksUri: `${AUTH0_DOMAIN}/.well-known/jwks.json`,
+  }) as GetVerificationKey,
+
+  // Validate the audience and the issuer.
+  audience: AUTH0_AUDIENCE,
+  issuer: [`${AUTH0_DOMAIN}/`],
+  algorithms: ["RS256"],
+})

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -6,6 +6,8 @@ import { template } from "lodash"
 
 import { APPLICATION_NAME, GIT_COMMIT_HASH, RELEASE_TAG } from "@/config"
 
+import jwtMiddleware from "@/middlewares/jwt-middleware"
+
 export const router = Router()
 
 // some routes
@@ -15,6 +17,8 @@ router.route("/_status").get((req: Request, res: Response) => {
     GIT_COMMIT_HASH,
   })
 })
+
+router.use("/api", jwtMiddleware)
 
 // if no other api routes match, send the 404 page
 router.use("/api", (req: Request, res: Response) => {

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -11,9 +11,9 @@ x-default-environment: &default-environment
   FRONTEND_URL: "http://localhost:8080"
   VITE_APPLICATION_NAME: "Internal Data Portal"
   VITE_API_BASE_URL: "http://localhost:3000"
-  VITE_AUTH0_CLIENT_ID": "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k"
-  VITE_AUTH0_AUDIENCE": "testing"
-  VITE_AUTH0_DOMAIN": "https://dev-0tc6bn14.eu.auth0.com"
+  VITE_AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k"
+  VITE_AUTH0_AUDIENCE: "testing"
+  VITE_AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com"
   RELEASE_TAG: "${RELEASE_TAG:-development}"
   GIT_COMMIT_HASH: "${GIT_COMMIT_HASH:-not-set}"
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -5,25 +5,25 @@
 </template>
 
 <script lang="ts" setup>
-import { useAuth0 } from "@auth0/auth0-vue"
-import { watch } from "vue"
-import { useRouter } from "vue-router"
+// import { useAuth0 } from "@auth0/auth0-vue"
+// import { watch } from "vue"
+// import { useRouter } from "vue-router"
 
-const router = useRouter()
-const { isLoading, isAuthenticated } = useAuth0()
+// const router = useRouter()
+// const { isLoading, isAuthenticated } = useAuth0()
 
 // TODO: this is hacked-together, it should reworked before final usage
-watch(
-  () => [isLoading.value, isAuthenticated.value],
-  ([newIsLoading, newIsAuthenticated], _) => {
-    if (newIsLoading === false && newIsAuthenticated === true) {
-      router.push("/dashboard")
-    } else if (!newIsLoading && !isAuthenticated.value) {
-      router.push("/sign-in")
-    }
-  },
-  {
-    immediate: true,
-  }
-)
+// watch(
+//   () => [isLoading.value, isAuthenticated.value],
+//   ([newIsLoading, newIsAuthenticated], _) => {
+//     if (newIsLoading === false && newIsAuthenticated === true) {
+//       router.push("/dashboard")
+//     } else if (!newIsLoading && !isAuthenticated.value) {
+//       router.push("/sign-in")
+//     }
+//   },
+//   {
+//     immediate: true,
+//   }
+// )
 </script>

--- a/web/src/api/http-client.ts
+++ b/web/src/api/http-client.ts
@@ -2,9 +2,7 @@ import qs from "qs"
 import axios from "axios"
 
 import { API_BASE_URL } from "@/config"
-import { useAuth0 } from "@auth0/auth0-vue"
-
-const { getAccessTokenSilently, loginWithRedirect } = useAuth0()
+import auth0 from "@/plugins/auth0-plugin"
 
 export const httpClient = axios.create({
   baseURL: API_BASE_URL,
@@ -19,7 +17,7 @@ export const httpClient = axios.create({
 })
 
 httpClient.interceptors.request.use(async (config) => {
-  const accessToken = await getAccessTokenSilently()
+  const accessToken = await auth0.getAccessTokenSilently()
   config.headers["Authorization"] = `Bearer ${accessToken}`
   return config
 })
@@ -30,7 +28,7 @@ httpClient.interceptors.response.use(null, async (error) => {
   // Bounce the user if they hit a login required error when trying to access a protected route
   // It would probably be better to move this code to a route guard or something?
   if (error?.error === "login_required") {
-    await loginWithRedirect({
+    await auth0.loginWithRedirect({
       appState: { targetUrl: window.location.pathname },
     })
   } else if (error?.response?.data?.message) {

--- a/web/src/api/http-client.ts
+++ b/web/src/api/http-client.ts
@@ -17,8 +17,12 @@ export const httpClient = axios.create({
 })
 
 httpClient.interceptors.request.use(async (config) => {
-  const accessToken = await auth0.getAccessTokenSilently()
-  config.headers["Authorization"] = `Bearer ${accessToken}`
+  // Only add the Authorization header to requests that start with "/api"
+  if (config.url?.startsWith("/api")) {
+    const accessToken = await auth0.getAccessTokenSilently()
+    config.headers["Authorization"] = `Bearer ${accessToken}`
+  }
+
   return config
 })
 


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/10

See https://github.com/icefoganalytics/travel-authorization/issues/151

**Describe the bug**
Go to this file `api/tsconfig.json` and see that it is showing as errored. This error doesn't seem to have any effect, but it has the potential to hide meaningful errors and creates noise when developing.

```
Cannot find type definition file for 'express-unless'.
  The file is in the program because:
    Entry point for implicit type library 'express-unless'
```

Solution is likely to upgrade express-jwt. See https://github.com/auth0/express-jwt/issues/307

**Screenshots**
![image](https://github.com/icefoganalytics/travel-authorization/assets/23045206/f4c66332-8e97-40b5-96d6-55126e44764b)

# Implementation

Upgrade express-jwt to fix tsconfig.json error.
Upgrade jwks-rsa to match example from documentation.
Use type casting to make jwksRsa work with express-jwt as per https://github.com/auth0/node-jwks-rsa/issues/308
Only require auth0 token for /api routes when using http-client.

# Testing Instructions

1. Boot the app via `dev up`
2. Go to http://localhost:3000/api/500 to check that jwt middleware is kicking in.
3. Go to splash page at http://localhost:8080/
4. Go to status page at http://localhost:8080/status
