### PR TITLE
Fixup: Local Production Build Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,23 @@ Files:
 1. Create a `.env` file in top level directory with the appropriate values.
 
    ```bash
-   APPLICATION_NAME=Internal Data Portal
+   NODE_ENV=production
+
+   VITE_APPLICATION_NAME=Internal Data Portal
+   VITE_AUTH0_DOMAIN=https://dev-0tc6bn14.eu.auth0.com
+   VITE_AUTH0_CLIENT_ID=mS8zklFSgatWX3v1OCQgVpEq5MixCm4k
+   VITE_AUTH0_AUDIENCE=testing
+
+   FRONTEND_URL=http://localhost:8080
+   API_PORT=8080
 
    DB_HOST=db
    DB_PORT=1433
    DB_USER=sa
    DB_PASS=DevPwd99!
    DB_NAME=idp_production
+
+   PRODUCTION_DATABASE_SA_MASTER_CREDS_AVAILABLE=true
 
    YUKON_GOVERNMENT_OCP_APIM_SUBSCRIPTION_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxx
    ```
@@ -289,6 +299,6 @@ Files:
    docker compose up --build
    ```
 
-4. Go to http://localhost:3000/ and log in.
+4. Go to http://localhost:8080/ and log in.
 
 5. Navigate around the app and do some stuff and see if it works.

--- a/api/jest.config.ts
+++ b/api/jest.config.ts
@@ -1,7 +1,6 @@
 import type { JestConfigWithTsJest } from "ts-jest"
 
 export const jestConfig: JestConfigWithTsJest = {
-  preset: "ts-jest",
   testEnvironment: "node",
   moduleNameMapper: {
     "^@/(.*)$": ["<rootDir>/src/$1", "<rootDir>/tests/$1"],
@@ -14,6 +13,15 @@ export const jestConfig: JestConfigWithTsJest = {
   resetMocks: true,
   restoreMocks: true,
   resetModules: true,
+  // https://kulshekhar.github.io/ts-jest/docs/getting-started/options/#introduction
+  transform: {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        tsconfig: "<rootDir>/tests/tsconfig.json",
+      },
+    ],
+  },
 }
 
 export default jestConfig

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@faker-js/faker": "^8.4.0",
         "axios": "^1.6.5",
         "cls-hooked": "^4.2.2",
         "cors": "^2.8.5",
@@ -25,7 +26,6 @@
         "umzug": "^3.5.0"
       },
       "devDependencies": {
-        "@faker-js/faker": "^8.4.0",
         "@types/cls-hooked": "^4.3.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
@@ -1066,7 +1066,6 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.0.tgz",
       "integrity": "sha512-htW87352wzUCdX1jyUQocUcmAaFqcR/w082EC8iP/gtkF0K+aKcBp0hR5Arb7dzR8tQ1TrhE9DNa5EbJELm84w==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
   "author": "Michael Johnson",
   "license": "ISC",
   "dependencies": {
+    "@faker-js/faker": "^8.4.0",
     "axios": "^1.6.5",
     "cls-hooked": "^4.2.2",
     "cors": "^2.8.5",
@@ -32,7 +33,6 @@
     "umzug": "^3.5.0"
   },
   "devDependencies": {
-    "@faker-js/faker": "^8.4.0",
     "@types/cls-hooked": "^4.3.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -28,7 +28,6 @@ export const API_PORT = process.env.API_PORT || "3000"
 export const FRONTEND_URL = process.env.FRONTEND_URL || ""
 export const AUTH0_DOMAIN = stripTrailingSlash(process.env.VITE_AUTH0_DOMAIN || "")
 export const AUTH0_AUDIENCE = process.env.VITE_AUTH0_AUDIENCE
-export const AUTH0_REDIRECT = process.env.VITE_AUTH0_REDIRECT || process.env.FRONTEND_URL || ""
 
 export const APPLICATION_NAME = process.env.VITE_APPLICATION_NAME || ""
 

--- a/api/src/serializers/datasets/table-helpers/determine-access.ts
+++ b/api/src/serializers/datasets/table-helpers/determine-access.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isNil, isUndefined } from "lodash"
+import { isEmpty, isNil } from "lodash"
 
 import { Dataset, User, AccessGrant, UserGroupMembership } from "@/models"
 import { AccessTypes, GrantLevels, orderOfAccessType } from "@/models/access-grant"
@@ -6,7 +6,7 @@ import { AccessTypes, GrantLevels, orderOfAccessType } from "@/models/access-gra
 export function determineAccess(record: Dataset, requestingUser: User): AccessTypes {
   const { accessGrants, owner } = record
 
-  if (isUndefined(accessGrants) || isEmpty(accessGrants) || isUndefined(owner)) {
+  if (isNil(accessGrants) || isEmpty(accessGrants) || isNil(owner)) {
     return AccessTypes.NO_ACCESS
   }
 
@@ -20,7 +20,7 @@ export function determineAccess(record: Dataset, requestingUser: User): AccessTy
       const { grantLevel } = accessGrant
       const { groupMembership: ownerGroupMembership } = owner
       const { groupMembership: requestingUserGroupMembership } = requestingUser
-      if (isUndefined(ownerGroupMembership) || isUndefined(requestingUserGroupMembership)) {
+      if (isNil(ownerGroupMembership) || isNil(requestingUserGroupMembership)) {
         return currentAccess
       }
 

--- a/api/tests/tsconfig.json
+++ b/api/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./../src/*", "./../tests/*"]
+    }
+  },
+  "include": ["../src/**/*", "../tests/**/*"]
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     "baseUrl": "." /* Base directory to resolve non-absolute module names. */,
     "paths": {
-      "@/*": ["./src/*", "./dist/*", "./tests/*"]
+      "@/*": ["./src/*", "./dist/*"]
     },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     /* List of folders to include type definitions from. */
@@ -27,5 +27,5 @@
     "emitDecoratorMetadata": true,
     "incremental": true
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*"]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - "${HOST_PORT:-3000}:3000"
+      - "${HOST_PORT:-8080}:8080"
     volumes:
       - ./.env:/home/node/app/.env.production
     depends_on:

--- a/web/src/api/status-api.ts
+++ b/web/src/api/status-api.ts
@@ -7,7 +7,7 @@ export type Status = {
 
 export const statusApi = {
   async fetchStatus(): Promise<Status> {
-    const { data } = await http.get("_status")
+    const { data } = await http.get("/_status")
     return data
   },
 }

--- a/web/src/components/datasets/NewDatasetForm.vue
+++ b/web/src/components/datasets/NewDatasetForm.vue
@@ -281,7 +281,7 @@ const {
   userGroups: departments,
   isLoading: isLoadingDepartments,
   fetch: fetchDepartments,
-} = useUserGroups(departmentsQuery, { immediate: false })
+} = useUserGroups(departmentsQuery, { immediate: true })
 const {
   userGroups: divisions,
   isLoading: isLoadingDivisions,
@@ -381,10 +381,6 @@ async function updateDepartment(newDepartmentId: number | null) {
   }
 
   departmentId.value = newDepartmentId
-  if (departments.value.length === 0) {
-    await fetchDepartments()
-  }
-
   const department = departments.value.find((department) => department.id === newDepartmentId)
   if (department === undefined) {
     throw new Error(`Could not find department with id ${newDepartmentId}`)

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,15 +1,41 @@
-import { stripTrailingSlash } from "@/utils/strip-trailing-slash"
+type Environments = "development" | "production"
 
-export const ENVIRONMENT = import.meta.env.MODE
+type ConfigAttributes = {
+  API_BASE_URL: string
+  AUTH0_DOMAIN: string
+  AUTH0_CLIENT_ID: string
+  AUTH0_AUDIENCE: string
+}
 
-// Generally we use window.location.origin for the redirect_uri but if
-// you may want to use a different URL for the redirect_uri. Make sure you
-// make the related changes in @/config.js and @/plugins/auth.js
-export const APPLICATION_NAME = import.meta.env.VITE_APPLICATION_NAME || ""
-export const APPLICATION_ICON = "mdi-cable-data"
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ""
+const CONFIGS: {
+  [key in Environments]: ConfigAttributes
+} = {
+  development: {
+    API_BASE_URL: "http://localhost:3000",
+    AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com",
+    AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k",
+    AUTH0_AUDIENCE: "testing",
+  },
+  // Make sure that it's still possible to build locally in production mode
+  // even after this gets changed, whether via environment variables in
+  // docker-compose.yml or some other method
+  production: {
+    API_BASE_URL: "",
+    AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com",
+    AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k",
+    AUTH0_AUDIENCE: "testing",
+  },
+}
 
-export const AUTH0_DOMAIN = stripTrailingSlash(import.meta.env.VITE_AUTH0_DOMAIN || "")
-export const AUTH0_AUDIENCE = import.meta.env.VITE_AUTH0_AUDIENCE || ""
-export const AUTH0_REDIRECT = import.meta.env.VITE_AUTH0_REDIRECT || ""
-export const AUTH0_CLIENT_ID = import.meta.env.VITE_AUTH0_CLIENT_ID || ""
+export const ENVIRONMENT = import.meta.env.MODE as Environments
+
+if (!(ENVIRONMENT in CONFIGS)) {
+  throw new Error(`Invalid environment: ${ENVIRONMENT}`)
+}
+
+const config: ConfigAttributes = CONFIGS[ENVIRONMENT]
+
+export const APPLICATION_NAME = "Internal Data Portal"
+export const { API_BASE_URL, AUTH0_DOMAIN, AUTH0_CLIENT_ID, AUTH0_AUDIENCE } = config
+
+export default config


### PR DESCRIPTION
# Context

Add ability to build app in production mode and log in.

# Implementation

Break `tsconfig.json` test config from production `tsconfig.json`
Integrate configs inline for front-end.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Check that VS Code correctly loads @ paths in `api/tests/utils/deep-pick.test.ts`
3. Boot the app via `dc up --build`
4. Log in to the app at http://localhost:8080, this will create
5. Open your database editor and go to the `idp_production` database.
6. Change your user's role to "system_admin" and save the change.
7. Update your user's first/last name and position as needed.
8. From the /dashboard page click the "Sync user groups" button.
9. Create a dataset.
