### PR TITLE
Part 3: Data Owner: Edit an Existing Dataset - Add Keywords and Owner Notes

### DIFF
--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,8 +1,9 @@
 export { CurrentUserController } from "./current-user-controller"
 export { DatasetsController } from "./datasets-controller"
 export { DatasetStewardshipsController } from "./dataset-stewardships-controller"
-export { UsersController } from "./users-controller"
+export { TagsController } from "./tags-controller"
 export { UserGroupsController } from "./user-groups-controller"
+export { UsersController } from "./users-controller"
 
 export * as Users from "./users"
 export * as UserGroups from "./user-groups"

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,6 +1,7 @@
 export { CurrentUserController } from "./current-user-controller"
 export { DatasetsController } from "./datasets-controller"
 export { DatasetStewardshipsController } from "./dataset-stewardships-controller"
+export { TaggingsController } from "./taggings-controller"
 export { TagsController } from "./tags-controller"
 export { UserGroupsController } from "./user-groups-controller"
 export { UsersController } from "./users-controller"

--- a/api/src/controllers/taggings-controller.ts
+++ b/api/src/controllers/taggings-controller.ts
@@ -1,0 +1,25 @@
+import { WhereOptions } from "sequelize"
+
+import { Tagging } from "@/models"
+
+import BaseController from "@/controllers/base-controller"
+
+export class TaggingsController extends BaseController {
+  async index() {
+    const where = this.query.where as WhereOptions<Tagging>
+    console.log(`where:`, where)
+    const totalCount = await Tagging.count({ where })
+    const taggings = await Tagging.findAll({
+      where,
+      limit: this.pagination.limit,
+      offset: this.pagination.offset,
+      include: ["tag"],
+      // TODO: consider ordering in the front-end, to avoid OS specific ordering issues.
+      order: [["tag", "name", "ASC"]],
+    })
+
+    return this.response.json({ taggings, totalCount })
+  }
+}
+
+export default TaggingsController

--- a/api/src/controllers/taggings-controller.ts
+++ b/api/src/controllers/taggings-controller.ts
@@ -11,7 +11,7 @@ import BaseController from "@/controllers/base-controller"
 export class TaggingsController extends BaseController {
   async index() {
     const where = this.query.where as WhereOptions<Tagging>
-    console.log(`where:`, where)
+
     const totalCount = await Tagging.count({ where })
     const taggings = await Tagging.findAll({
       where,

--- a/api/src/controllers/taggings-controller.ts
+++ b/api/src/controllers/taggings-controller.ts
@@ -1,6 +1,10 @@
 import { WhereOptions } from "sequelize"
+import { isNil } from "lodash"
 
-import { Tagging } from "@/models"
+import { Dataset, Tagging } from "@/models"
+import { Taggable, TaggableTypes } from "@/models/tagging"
+import { DatasetsPolicy } from "@/policies"
+import { CreateService } from "@/services/taggings"
 
 import BaseController from "@/controllers/base-controller"
 
@@ -19,6 +23,45 @@ export class TaggingsController extends BaseController {
     })
 
     return this.response.json({ taggings, totalCount })
+  }
+
+  async create() {
+    const taggable = await this.loadTaggable()
+    // TODO: consider if this should return a 403 to prevent an enumeration attack.
+    if (isNil(taggable)) {
+      return this.response.status(404).json({ message: "Taggable not found." })
+    }
+
+    const policy = this.buildPolicy(taggable)
+    if (!policy.create()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to create taggings against this taggable." })
+    }
+
+    try {
+      const tagging = await CreateService.perform(this.request.body, this.currentUser)
+      return this.response.status(201).json({ tagging })
+    } catch (error) {
+      return this.response.status(422).json({ message: `Tagging creation failed: ${error}` })
+    }
+  }
+
+  private async loadTaggable(): Promise<Dataset | null> {
+    const { taggableType, taggableId } = this.request.body
+    if (taggableType === TaggableTypes.DATASET) {
+      return Dataset.findByPk(taggableId)
+    } else {
+      throw new Error(`Unsupported taggableType: ${taggableType}`)
+    }
+  }
+
+  private buildPolicy(taggable: Taggable) {
+    if (taggable instanceof Dataset) {
+      return new DatasetsPolicy(this.currentUser, taggable)
+    } else {
+      throw new Error("Could not build policy for taggable")
+    }
   }
 }
 

--- a/api/src/controllers/tags-controller.ts
+++ b/api/src/controllers/tags-controller.ts
@@ -13,7 +13,6 @@ export class TagsController extends BaseController {
       where,
       limit: this.pagination.limit,
       offset: this.pagination.offset,
-      // TODO: consider ordering in the front-end, to avoid OS specific ordering issues.
       order: [["name", "ASC"]],
     })
 

--- a/api/src/controllers/tags-controller.ts
+++ b/api/src/controllers/tags-controller.ts
@@ -1,0 +1,24 @@
+import { WhereOptions } from "sequelize"
+
+import { Tag } from "@/models"
+
+import BaseController from "@/controllers/base-controller"
+
+export class TagsController extends BaseController {
+  async index() {
+    const where = this.query.where as WhereOptions<Tag>
+
+    const totalCount = await Tag.count({ where })
+    const tags = await Tag.findAll({
+      where,
+      limit: this.pagination.limit,
+      offset: this.pagination.offset,
+      // TODO: consider ordering in the front-end, to avoid OS specific ordering issues.
+      order: [["name", "ASC"]],
+    })
+
+    return this.response.json({ tags, totalCount })
+  }
+}
+
+export default TagsController

--- a/api/src/models/tagging.ts
+++ b/api/src/models/tagging.ts
@@ -7,7 +7,6 @@ import {
   BelongsToSetAssociationMixinOptions,
   CreationOptional,
   DataTypes,
-  FindOptions,
   ForeignKey,
   InferAttributes,
   InferCreationAttributes,
@@ -63,8 +62,10 @@ export class Tagging extends Model<InferAttributes<Tagging>, InferCreationAttrib
   }
 
   static establishAssociations() {
-    this.belongsTo(Tag)
-
+    this.belongsTo(Tag, {
+      foreignKey: "tagId",
+      as: "tag",
+    })
     // specific taggable type implementations
     this.belongsTo(Dataset, {
       foreignKey: "taggableId",
@@ -173,7 +174,7 @@ Tagging.init(
     hooks: {
       // See https://sequelize.org/docs/v6/advanced-association-concepts/polymorphic-associations/#configuring-a-one-to-many-polymorphic-association
       // afterFind(instancesOrInstance: readonly M[] | M | null, options: FindOptions<TAttributes>): HookReturn;
-      afterFind: (findResult: Tagging[] | Tagging | null, options: FindOptions<Tagging>) => {
+      afterFind: (findResult: Tagging[] | Tagging | null) => {
         if (isNil(findResult) || isEmpty(findResult)) return Promise.resolve()
 
         let findResultArray: Tagging[]
@@ -191,7 +192,7 @@ Tagging.init(
           // To prevent mistakes:
           delete instance.dataset
           // Sequelize 7 might not raise an error here, or it might make this code unnecessary.
-          // @ts-expect-error
+          // @ts-expect-error - See documentation https://sequelize.org/docs/v6/advanced-association-concepts/polymorphic-associations/#configuring-a-one-to-many-polymorphic-association
           delete instance.dataValues.dataset
         }
       },

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -66,7 +66,7 @@ router
   .route("/api/user-groups/yukon-government-directory-sync")
   .post(UserGroups.YukonGovernmentDirectorySyncController.create)
 
-router.route("/api/taggings").get(TaggingsController.index)
+router.route("/api/taggings").get(TaggingsController.index).post(TaggingsController.create)
 router.route("/api/tags").get(TagsController.index)
 
 // TODO: might want to lock these to only run in non-production environments?

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -67,6 +67,7 @@ router
   .post(UserGroups.YukonGovernmentDirectorySyncController.create)
 
 router.route("/api/taggings").get(TaggingsController.index).post(TaggingsController.create)
+router.route("/api/taggings/:taggingId").delete(TaggingsController.destroy)
 router.route("/api/tags").get(TagsController.index)
 
 // TODO: might want to lock these to only run in non-production environments?
@@ -77,7 +78,7 @@ router
 
 // if no other routes match, return a 404
 router.use("/api", (req: Request, res: Response) => {
-  return res.status(404).json({ message: "Not Found" })
+  return res.status(404).json({ message: `Resource not found for ${req.path}` })
 })
 
 // Special error handler for all api errors

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -20,12 +20,13 @@ import { ensureAndAuthorizeCurrentUser } from "@/middlewares/authorization-middl
 import {
   CurrentUserController,
   DatasetsController,
-  UsersController,
-  Users,
+  DatasetStewardshipsController,
+  QaScenarios,
+  TagsController,
   UserGroups,
   UserGroupsController,
-  QaScenarios,
-  DatasetStewardshipsController,
+  Users,
+  UsersController,
 } from "@/controllers"
 
 export const router = Router()
@@ -63,6 +64,8 @@ router.route("/api/user-groups").get(UserGroupsController.index)
 router
   .route("/api/user-groups/yukon-government-directory-sync")
   .post(UserGroups.YukonGovernmentDirectorySyncController.create)
+
+router.route("/api/tags").get(TagsController.index)
 
 // TODO: might want to lock these to only run in non-production environments?
 router.route("/api/qa-scenarios/link-random-tags").post(QaScenarios.LinkRandomTagsController.create)

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -22,6 +22,7 @@ import {
   DatasetsController,
   DatasetStewardshipsController,
   QaScenarios,
+  TaggingsController,
   TagsController,
   UserGroups,
   UserGroupsController,
@@ -65,6 +66,7 @@ router
   .route("/api/user-groups/yukon-government-directory-sync")
   .post(UserGroups.YukonGovernmentDirectorySyncController.create)
 
+router.route("/api/taggings").get(TaggingsController.index)
 router.route("/api/tags").get(TagsController.index)
 
 // TODO: might want to lock these to only run in non-production environments?

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,4 +1,5 @@
 export * as Datasets from "./datasets"
 export * as DatasetStewardships from "./dataset-stewardships"
+export * as Taggings from "./taggings"
 export * as UserGroups from "./user-groups"
 export * as Users from "./users"

--- a/api/src/services/taggings/create-service.ts
+++ b/api/src/services/taggings/create-service.ts
@@ -54,7 +54,7 @@ export class CreateService extends BaseService {
         tagId: effectiveTagId,
       })
 
-      // TODO: log creating user?
+      // TODO: log creating user
 
       return tagging.reload({ include: ["tag"] })
     })

--- a/api/src/services/taggings/create-service.ts
+++ b/api/src/services/taggings/create-service.ts
@@ -36,7 +36,8 @@ export class CreateService extends BaseService {
           throw new Error("tagAttributes.name is required when tagId was not provided")
         }
 
-        const tag = await Tag.create({ name })
+        const cleanName = name.trim().toLocaleLowerCase()
+        const tag = await Tag.create({ name: cleanName })
 
         if (isNil(tag)) {
           throw new Error("Tag creation failed")

--- a/api/src/services/taggings/create-service.ts
+++ b/api/src/services/taggings/create-service.ts
@@ -1,0 +1,63 @@
+import { isNil } from "lodash"
+
+import db, { Tag, Tagging, User } from "@/models"
+
+import BaseService from "@/services/base-service"
+
+type Attributes = Partial<Tagging> & {
+  tagAttributes: Partial<Tag>
+}
+
+export class CreateService extends BaseService {
+  private attributes: Partial<Tagging>
+  private tagAttributes: Partial<Tag>
+
+  constructor(
+    { tagAttributes, ...attributes }: Attributes,
+    private currentUser: User
+  ) {
+    super()
+    this.attributes = attributes
+    this.tagAttributes = tagAttributes
+  }
+
+  async perform(): Promise<Tagging> {
+    const { taggableType, taggableId, tagId } = this.attributes
+
+    if (isNil(taggableType) || isNil(taggableId)) {
+      throw new Error("taggableType and taggableId are required")
+    }
+
+    return db.transaction(async () => {
+      let effectiveTagId: number
+      if (isNil(tagId)) {
+        const { name } = this.tagAttributes
+        if (isNil(name)) {
+          throw new Error("tagAttributes.name is required when tagId was not provided")
+        }
+
+        const tag = await Tag.create({ name })
+
+        if (isNil(tag)) {
+          throw new Error("Tag creation failed")
+        }
+
+        effectiveTagId = tag.id
+      } else {
+        effectiveTagId = tagId
+      }
+
+      const tagging = await Tagging.create({
+        taggableType,
+        taggableId,
+        tagId: effectiveTagId,
+      })
+
+      // TODO: log creating user?
+
+      return tagging.reload({ include: ["tag"] })
+    })
+  }
+}
+
+export default CreateService

--- a/api/src/services/taggings/destroy-service.ts
+++ b/api/src/services/taggings/destroy-service.ts
@@ -1,0 +1,31 @@
+import db, { Tag, Tagging, User } from "@/models"
+
+import BaseService from "@/services/base-service"
+
+export class DestroyService extends BaseService {
+  constructor(
+    private tagging: Tagging,
+    private currentUser: User
+  ) {
+    super()
+  }
+
+  async perform(): Promise<void> {
+    return db.transaction(async () => {
+      const { tagId } = this.tagging
+
+      await this.tagging.destroy()
+
+      const taggingsCount = await Tagging.count({ where: { tagId } })
+      if (taggingsCount === 0) {
+        await Tag.destroy({ where: { id: tagId } })
+      }
+
+      // TODO: log acting user
+
+      return
+    })
+  }
+}
+
+export default DestroyService

--- a/api/src/services/taggings/index.ts
+++ b/api/src/services/taggings/index.ts
@@ -1,0 +1,1 @@
+export { CreateService } from "./create-service"

--- a/api/src/services/taggings/index.ts
+++ b/api/src/services/taggings/index.ts
@@ -1,1 +1,2 @@
 export { CreateService } from "./create-service"
+export { DestroyService } from "./destroy-service"

--- a/web/src/api/taggings-api.ts
+++ b/web/src/api/taggings-api.ts
@@ -1,0 +1,42 @@
+import { Tag } from "@/api/tags-api"
+
+import http from "@/api/http-client"
+
+export enum TaggableTypes {
+  DATASET = "Dataset", //
+  // OTHER_MODEL = 'OtherModel'
+}
+
+export type Tagging = {
+  id: number
+  tagId: Tag["id"]
+  taggableId: number
+  taggableType: TaggableTypes
+  createdAt: string
+  updatedAt: string
+
+  // associations
+  tag?: Tag
+}
+
+export const taggingsApi = {
+  async list({
+    where,
+    page,
+    perPage,
+  }: {
+    where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
+    page?: number
+    perPage?: number
+  } = {}): Promise<{
+    taggings: Tagging[]
+    totalCount: number
+  }> {
+    const { data } = await http.get("/api/taggings", {
+      params: { where, page, perPage },
+    })
+    return data
+  },
+}
+
+export default taggingsApi

--- a/web/src/api/taggings-api.ts
+++ b/web/src/api/taggings-api.ts
@@ -37,6 +37,16 @@ export const taggingsApi = {
     })
     return data
   },
+  async create(
+    attributes: Partial<Tagging> & {
+      tagAttributes?: Partial<Tag>
+    }
+  ): Promise<{
+    tagging: Tagging & { tag: Tag }
+  }> {
+    const { data } = await http.post("/api/taggings", attributes)
+    return data
+  },
 }
 
 export default taggingsApi

--- a/web/src/api/taggings-api.ts
+++ b/web/src/api/taggings-api.ts
@@ -47,6 +47,10 @@ export const taggingsApi = {
     const { data } = await http.post("/api/taggings", attributes)
     return data
   },
+  async delete(taggingId: number): Promise<void> {
+    const { data } = await http.delete(`/api/taggings/${taggingId}`)
+    return data
+  },
 }
 
 export default taggingsApi

--- a/web/src/api/tags-api.ts
+++ b/web/src/api/tags-api.ts
@@ -1,0 +1,30 @@
+import http from "@/api/http-client"
+
+export type Tag = {
+  id: number
+  name: string
+  createdAt: string
+  updatedAt: string
+}
+
+export const tagsApi = {
+  async list({
+    where,
+    page,
+    perPage,
+  }: {
+    where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
+    page?: number
+    perPage?: number
+  } = {}): Promise<{
+    tags: Tag[]
+    totalCount: number
+  }> {
+    const { data } = await http.get("/api/tags", {
+      params: { where, page, perPage },
+    })
+    return data
+  },
+}
+
+export default tagsApi

--- a/web/src/components/SaveStateProgress.vue
+++ b/web/src/components/SaveStateProgress.vue
@@ -1,0 +1,52 @@
+<template>
+  <v-progress-circular
+    v-if="isSaving"
+    indeterminate
+    color="primary"
+    size="30"
+    width="4"
+  />
+  <v-icon
+    v-else
+    size="30"
+    title="Save"
+    :color="isInPostSaveStateTemporarily ? 'green' : 'light-green'"
+    :class="{ pulse: isInPostSaveStateTemporarily }"
+  >
+    mdi-check-circle
+  </v-icon>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from "vue"
+const props = defineProps({
+  saving: Boolean,
+})
+const isSaving = ref(props.saving)
+const isInPostSaveStateTemporarily = ref(false)
+watch(
+  () => props.saving,
+  (newValue) => {
+    isSaving.value = newValue
+    if (!newValue) {
+      isInPostSaveStateTemporarily.value = true
+      setTimeout(() => (isInPostSaveStateTemporarily.value = false), 500)
+    }
+  }
+)
+</script>
+
+<style scoped>
+.pulse {
+  animation: pulseAnimation 500ms forwards;
+}
+@keyframes pulseAnimation {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.3);
+  }
+}
+</style>

--- a/web/src/components/SaveStateProgress.vue
+++ b/web/src/components/SaveStateProgress.vue
@@ -13,20 +13,34 @@
     variant="outlined"
     rounded="circle"
     size="26"
-    title="Save"
+    :title="title"
     v-bind="$attrs"
   >
-    <v-icon size="18">mdi-check</v-icon>
+    <v-icon size="18">{{ icon }}</v-icon>
   </v-btn>
 </template>
 
 <script lang="ts" setup>
 import { ref, watch } from "vue"
+
 const props = defineProps({
-  saving: Boolean,
+  saving: {
+    type: Boolean,
+    default: false,
+  },
+  icon: {
+    type: String,
+    default: "mdi-check",
+  },
+  title: {
+    type: String,
+    default: "Save",
+  },
 })
+
 const isSaving = ref(props.saving)
 const isInPostSaveStateTemporarily = ref(false)
+
 watch(
   () => props.saving,
   (newValue) => {

--- a/web/src/components/SaveStateProgress.vue
+++ b/web/src/components/SaveStateProgress.vue
@@ -3,18 +3,21 @@
     v-if="isSaving"
     indeterminate
     color="primary"
-    size="30"
-    width="4"
+    size="26"
+    width="2"
   />
-  <v-icon
+  <v-btn
     v-else
-    size="30"
-    title="Save"
-    :color="isInPostSaveStateTemporarily ? 'green' : 'light-green'"
+    :color="isInPostSaveStateTemporarily ? 'success' : 'primary'"
     :class="{ pulse: isInPostSaveStateTemporarily }"
+    variant="outlined"
+    rounded="circle"
+    size="26"
+    title="Save"
+    v-bind="$attrs"
   >
-    mdi-check-circle
-  </v-icon>
+    <v-icon size="18">mdi-check</v-icon>
+  </v-btn>
 </template>
 
 <script lang="ts" setup>
@@ -38,7 +41,7 @@ watch(
 
 <style scoped>
 .pulse {
-  animation: pulseAnimation 500ms forwards;
+  animation: pulseAnimation 300ms forwards;
 }
 @keyframes pulseAnimation {
   0%,
@@ -46,7 +49,7 @@ watch(
     transform: scale(1);
   }
   50% {
-    transform: scale(1.3);
+    transform: scale(1.2);
   }
 }
 </style>

--- a/web/src/components/datasets/DataDescriptionFormCard.vue
+++ b/web/src/components/datasets/DataDescriptionFormCard.vue
@@ -9,7 +9,10 @@
       />
       <v-form
         v-else
+        ref="form"
+        v-model="isValid"
         class="d-flex mt-6"
+        @submit.prevent="saveWrapper"
       >
         <v-row>
           <v-col
@@ -23,8 +26,10 @@
               >
                 <v-text-field
                   v-model="dataset.name"
-                  label="Name"
+                  :rules="[required]"
+                  label="Name *"
                   variant="outlined"
+                  required
                 />
               </v-col>
               <v-col
@@ -42,9 +47,11 @@
               <v-col cols="12">
                 <v-textarea
                   v-model="dataset.description"
-                  label="Description"
+                  :rules="[required]"
+                  label="Description *"
                   variant="outlined"
                   rows="6"
+                  required
                 />
               </v-col>
             </v-row>
@@ -132,12 +139,28 @@
                 class="d-flex justify-end"
               >
                 <v-btn
+                  v-if="isValid"
                   :loading="isLoading"
+                  type="submit"
                   color="primary"
-                  @click="saveWrapper"
                 >
                   Save
                 </v-btn>
+                <v-tooltip v-else>
+                  <template #activator="{ props: tooltipProps }">
+                    <span v-bind="tooltipProps">
+                      <v-btn
+                        disabled
+                        type="submit"
+                        color="primary"
+                      >
+                        Save
+                        <v-icon end>mdi-help-circle-outline</v-icon>
+                      </v-btn>
+                    </span>
+                  </template>
+                  <span class="text-white">Some required fields are blank.</span>
+                </v-tooltip>
               </v-col>
             </v-row>
           </v-col>
@@ -148,9 +171,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, toRefs } from "vue"
+import { computed, ref, toRefs } from "vue"
 import { isNil } from "lodash"
 
+import { type VForm } from "vuetify/lib/components/index.mjs"
+
+import { required } from "@/utils/validators"
 import { useSnack } from "@/use/use-snack"
 import { useDataset } from "@/use/use-dataset"
 
@@ -168,6 +194,8 @@ const { slug } = toRefs(props)
 const { dataset, isLoading, save } = useDataset(slug)
 const snack = useSnack()
 
+const form = ref<InstanceType<typeof VForm> | null>(null)
+const isValid = ref(null)
 const isInactive = computed<boolean>(() => !isNil(dataset.value?.deactivatedAt))
 
 function deactivateDataset(value: boolean | null) {

--- a/web/src/components/datasets/OwnerNotesFormCard.vue
+++ b/web/src/components/datasets/OwnerNotesFormCard.vue
@@ -4,7 +4,7 @@
       Owner Notes
       <SaveStateProgress
         :saving="isLoading"
-        @click="save"
+        @click="saveAndNotify"
       />
     </v-card-title>
 
@@ -24,7 +24,7 @@
               label="Notes"
               variant="outlined"
               rows="8"
-              @update:model-value="debouncedSave"
+              @update:model-value="debouncedSaveAndNotify"
             />
           </v-col>
         </v-row>
@@ -53,7 +53,7 @@ const { slug } = toRefs(props)
 const { dataset, save, isLoading } = useDataset(slug)
 const snack = useSnack()
 
-const debouncedSave = debounce(async () => {
+async function saveAndNotify() {
   try {
     await save()
     snack.notify("Notes saved", {
@@ -64,5 +64,7 @@ const debouncedSave = debounce(async () => {
       color: "error",
     })
   }
-}, 1000)
+}
+
+const debouncedSaveAndNotify = debounce(saveAndNotify, 1000)
 </script>

--- a/web/src/components/datasets/OwnerNotesFormCard.vue
+++ b/web/src/components/datasets/OwnerNotesFormCard.vue
@@ -1,16 +1,68 @@
 <template>
   <v-card>
-    <v-card-title>Owner Notes</v-card-title>
+    <v-card-title class="d-flex justify-space-between align-center">
+      Owner Notes
+      <SaveStateProgress
+        :saving="isLoading"
+        @click="save"
+      />
+    </v-card-title>
 
-    TODO: OwnerNotesFormCard.vue
+    <v-card-text>
+      <v-skeleton-loader
+        v-if="isNil(dataset)"
+        type="card"
+      />
+      <v-form
+        v-else
+        class="d-flex mt-6"
+      >
+        <v-row>
+          <v-col cols="12">
+            <v-textarea
+              v-model="dataset.ownerNotes"
+              label="Notes"
+              variant="outlined"
+              rows="8"
+              @update:model-value="debouncedSave"
+            />
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
   </v-card>
 </template>
 
 <script lang="ts" setup>
-defineProps({
+import { toRefs } from "vue"
+import { debounce, isNil } from "lodash"
+
+import useDataset from "@/use/use-dataset"
+import useSnack from "@/use/use-snack"
+
+import SaveStateProgress from "@/components/SaveStateProgress.vue"
+
+const props = defineProps({
   slug: {
     type: String,
     required: true,
   },
 })
+
+const { slug } = toRefs(props)
+const { dataset, save, isLoading } = useDataset(slug)
+const snack = useSnack()
+
+const debouncedSave = debounce(async () => {
+  try {
+    await save()
+    snack.notify("Notes saved", {
+      color: "success",
+    })
+  } catch (error) {
+    snack.notify("Error saving notes", {
+      color: "error",
+    })
+  }
+}, 1000)
 </script>

--- a/web/src/components/datasets/SubjectFormCard.vue
+++ b/web/src/components/datasets/SubjectFormCard.vue
@@ -2,15 +2,63 @@
   <v-card>
     <v-card-title>Subject</v-card-title>
 
-    TODO: SubjectFormCard.vue
+    <v-card-text>
+      <v-form
+        class="d-flex flex-column mt-6"
+        @submit.prevent="saveWrapper"
+      >
+        <v-row>
+          <v-col cols="12">
+            <TagsCombobox
+              :model-value="selectedTags"
+              label="Keywords"
+              variant="outlined"
+              @tag-added="addTagging"
+              @tag-removed="removeTagging"
+              @tag-created="addTaggingAndCreateTag"
+            />
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
   </v-card>
 </template>
 
 <script lang="ts" setup>
-defineProps({
+import { computed } from "vue"
+
+import useTaggings from "@/use/use-taggings"
+
+import TagsCombobox from "@/components/tags/TagsCombobox.vue"
+
+const props = defineProps({
   slug: {
     type: String,
     required: true,
   },
 })
+
+const taggingsQuery = computed(() => ({
+  dataset: {
+    slug: props.slug,
+  },
+}))
+const { taggings } = useTaggings(taggingsQuery)
+const selectedTags = computed(() => taggings.value.map((tagging) => tagging.tag))
+
+function addTagging(tagId: number) {
+  alert(`TODO: implement add tagging for ${tagId}`)
+}
+
+function removeTagging(tagId: number) {
+  alert(`TODO: implement remove tagging for ${tagId}`)
+}
+
+function addTaggingAndCreateTag(tagName: string) {
+  alert(`TODO: implement add tagging and create tag for ${tagName}`)
+}
+
+function saveWrapper() {
+  alert("TODO: implement save")
+}
 </script>

--- a/web/src/components/datasets/SubjectFormCard.vue
+++ b/web/src/components/datasets/SubjectFormCard.vue
@@ -1,7 +1,14 @@
 <template>
   <v-card>
-    <v-card-title>Subject</v-card-title>
-
+    <v-card-title class="d-flex justify-space-between align-center">
+      Subject
+      <SaveStateProgress
+        :saving="isLoading"
+        title="Refresh"
+        icon="mdi-cached"
+        @click="refresh"
+      />
+    </v-card-title>
     <v-card-text>
       <v-form class="d-flex flex-column mt-6">
         <v-row>
@@ -30,6 +37,7 @@ import taggingsApi, { TaggableTypes } from "@/api/taggings-api"
 import useTaggings from "@/use/use-taggings"
 import useDataset from "@/use/use-dataset"
 
+import SaveStateProgress from "@/components/SaveStateProgress.vue"
 import TagsCombobox from "@/components/tags/TagsCombobox.vue"
 
 const props = defineProps({
@@ -50,7 +58,11 @@ const taggingsQuery = computed(() => ({
     taggableId: dataset.value?.id,
   },
 }))
-const { taggings, fetch: fetchTaggings } = useTaggings(taggingsQuery, { immediate: false })
+const {
+  taggings,
+  fetch: fetchTaggings,
+  isLoading,
+} = useTaggings(taggingsQuery, { immediate: false })
 const selectedTags = computed(() => compact(taggings.value.map((tagging) => tagging.tag)))
 
 watch(
@@ -100,5 +112,10 @@ async function refreshTags() {
   }
 
   return tagsCombobox.value.refresh()
+}
+
+function refresh() {
+  refreshTags()
+  fetchTaggings()
 }
 </script>

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -1,0 +1,65 @@
+<template>
+  <v-combobox
+    :model-value="modelValue"
+    :items="tags"
+    :loading="isLoading"
+    label="Tags"
+    item-value="id"
+    item-title="name"
+    chips
+    multiple
+    closable-chips
+    @update:model-value="updateSelectedTags"
+    @update:search="updateSearch"
+  ></v-combobox>
+</template>
+
+<script lang="ts" setup>
+import { differenceBy } from "lodash"
+
+import useTags, { Tag } from "@/use/use-tags"
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: Tag[]
+  }>(),
+  {
+    modelValue: () => [],
+  }
+)
+
+const emit = defineEmits<{
+  "tag-removed": (tagId: number) => void
+  "tag-created": (tagName: string) => void
+  "tag-added": (tagId: number) => void
+}>()
+
+const { tags, isLoading } = useTags()
+
+function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
+  if (props.modelValue.length > newSelectedValues.length) {
+    const tagRemoved = differenceBy(props.modelValue, newSelectedValues, "id")[0]
+    emit("tag-removed", tagRemoved.id)
+
+    return
+  }
+
+  const newTagName: string | undefined = newSelectedValues.find(isString)
+  if (newTagName === undefined) {
+    const tagAdded = differenceBy(newSelectedValues, props.modelValue, "id")[0]
+    emit("tag-added", tagAdded.id)
+
+    return
+  }
+
+  emit("tag-created", newTagName)
+}
+
+function isString(value: Tag | string): value is string {
+  return typeof value === "string"
+}
+
+function updateSearch(value: string) {
+  console.log(`TODO: filter tag search from value:`, value)
+}
+</script>

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -16,6 +16,7 @@
 </template>
 
 <script lang="ts" setup>
+import { ref } from "vue"
 import { differenceBy } from "lodash"
 
 import useTags, { Tag } from "@/use/use-tags"
@@ -34,6 +35,10 @@ const emit = defineEmits<{
   tagCreated: [tagName: string]
   tagAdded: [tagId: number]
 }>()
+
+// TODO: make use of search token to filter results in the back-end
+// Probably best to add a custom /tags/search endpoint?
+const searchToken = ref<string>("")
 
 const { tags, isLoading, refresh } = useTags()
 
@@ -58,7 +63,7 @@ function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
 }
 
 function updateSearch(value: string) {
-  console.log(`TODO: filter tag search from value:`, value)
+  searchToken.value = value
 }
 
 function assertAreTags(values: (Tag | string)[]): asserts values is Tag[] {

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -29,9 +29,9 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  "tag-removed": (tagId: number) => void
-  "tag-created": (tagName: string) => void
-  "tag-added": (tagId: number) => void
+  tagRemoved: [tagId: number]
+  tagCreated: [tagName: string]
+  tagAdded: [tagId: number]
 }>()
 
 const { tags, isLoading } = useTags()
@@ -39,20 +39,27 @@ const { tags, isLoading } = useTags()
 function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
   if (props.modelValue.length > newSelectedValues.length) {
     const tagRemoved = differenceBy(props.modelValue, newSelectedValues, "id")[0]
-    emit("tag-removed", tagRemoved.id)
+    emit("tagRemoved", tagRemoved.id)
 
     return
   }
 
   const newTagName: string | undefined = newSelectedValues.find(isString)
   if (newTagName === undefined) {
-    const tagAdded = differenceBy(newSelectedValues, props.modelValue, "id")[0]
-    emit("tag-added", tagAdded.id)
+    assertAreTags(newSelectedValues)
+    const tagAdded: Tag = differenceBy(newSelectedValues, props.modelValue, "id")[0]
+    emit("tagAdded", tagAdded.id)
 
     return
   }
 
-  emit("tag-created", newTagName)
+  emit("tagCreated", newTagName)
+}
+
+function assertAreTags(values: (Tag | string)[]): asserts values is Tag[] {
+  if (values.some(isString)) {
+    throw new Error("Expected all values to be tags")
+  }
 }
 
 function isString(value: Tag | string): value is string {

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -6,9 +6,10 @@
     label="Tags"
     item-value="id"
     item-title="name"
+    auto-select-first
     chips
-    multiple
     closable-chips
+    multiple
     @update:model-value="updateSelectedTags"
     @update:search="updateSearch"
   ></v-combobox>

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue"
+import { computed, ref } from "vue"
 import { differenceBy } from "lodash"
 
 import useTags, { Tag } from "@/use/use-tags"
@@ -40,7 +40,11 @@ const emit = defineEmits<{
 // Probably best to add a custom /tags/search endpoint?
 const searchToken = ref<string>("")
 
-const { tags, isLoading, refresh } = useTags()
+// TODO: once search is implemented, this should be removed.
+const tagsQuery = computed(() => ({
+  perPage: 1000,
+}))
+const { tags, isLoading, refresh } = useTags(tagsQuery)
 
 function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
   if (props.modelValue.length > newSelectedValues.length) {
@@ -62,6 +66,7 @@ function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
   emit("tagCreated", newTagName)
 }
 
+// TODO: debounce search
 function updateSearch(value: string) {
   searchToken.value = value
 }

--- a/web/src/components/tags/TagsCombobox.vue
+++ b/web/src/components/tags/TagsCombobox.vue
@@ -34,7 +34,7 @@ const emit = defineEmits<{
   tagAdded: [tagId: number]
 }>()
 
-const { tags, isLoading } = useTags()
+const { tags, isLoading, refresh } = useTags()
 
 function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
   if (props.modelValue.length > newSelectedValues.length) {
@@ -56,6 +56,10 @@ function updateSelectedTags(newSelectedValues: (Tag | string)[]) {
   emit("tagCreated", newTagName)
 }
 
+function updateSearch(value: string) {
+  console.log(`TODO: filter tag search from value:`, value)
+}
+
 function assertAreTags(values: (Tag | string)[]): asserts values is Tag[] {
   if (values.some(isString)) {
     throw new Error("Expected all values to be tags")
@@ -66,7 +70,7 @@ function isString(value: Tag | string): value is string {
   return typeof value === "string"
 }
 
-function updateSearch(value: string) {
-  console.log(`TODO: filter tag search from value:`, value)
-}
+defineExpose({
+  refresh,
+})
 </script>

--- a/web/src/use/use-taggings.ts
+++ b/web/src/use/use-taggings.ts
@@ -1,0 +1,60 @@
+import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
+
+import taggingsApi, { type Tagging } from "@/api/taggings-api"
+
+export { type Tagging }
+
+export function useTaggings(
+  queryOptions: Ref<{
+    where?: Record<string, unknown>
+    page?: number
+    perPage?: number
+  }> = ref({}),
+  {
+    immediate = true,
+  }: {
+    immediate?: boolean
+  } = {}
+) {
+  const state = reactive<{
+    taggings: Tagging[]
+    isLoading: boolean
+    isErrored: boolean
+  }>({
+    taggings: [],
+    isLoading: false,
+    isErrored: false,
+  })
+
+  async function fetch(): Promise<Tagging[]> {
+    state.isLoading = true
+    try {
+      const { taggings } = await taggingsApi.list(unref(queryOptions))
+      state.isErrored = false
+      state.taggings = taggings
+      return taggings
+    } catch (error) {
+      console.error("Failed to fetch taggings:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  watch(
+    () => unref(queryOptions),
+    async () => {
+      await fetch()
+    },
+    { deep: true, immediate }
+  )
+
+  return {
+    ...toRefs(state),
+    fetch,
+    refresh: fetch,
+  }
+}
+
+export default useTaggings

--- a/web/src/use/use-tags.ts
+++ b/web/src/use/use-tags.ts
@@ -1,38 +1,35 @@
 import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
 
-import userGroupsApi, { type UserGroup } from "@/api/user-groups-api"
+import tagsApi, { type Tag } from "@/api/tags-api"
 
-export function useUserGroups(
+export { type Tag }
+
+export function useTags(
   queryOptions: Ref<{
     where?: Record<string, unknown>
     page?: number
     perPage?: number
-  }> = ref({}),
-  {
-    immediate = true,
-  }: {
-    immediate?: boolean
-  } = {}
+  }> = ref({})
 ) {
   const state = reactive<{
-    userGroups: UserGroup[]
+    tags: Tag[]
     isLoading: boolean
     isErrored: boolean
   }>({
-    userGroups: [],
+    tags: [],
     isLoading: false,
     isErrored: false,
   })
 
-  async function fetch(): Promise<UserGroup[]> {
+  async function fetch(): Promise<Tag[]> {
     state.isLoading = true
     try {
-      const { userGroups } = await userGroupsApi.list(unref(queryOptions))
+      const { tags } = await tagsApi.list(unref(queryOptions))
       state.isErrored = false
-      state.userGroups = userGroups
-      return userGroups
+      state.tags = tags
+      return tags
     } catch (error) {
-      console.error("Failed to fetch user groups:", error)
+      console.error("Failed to fetch tags:", error)
       state.isErrored = true
       throw error
     } finally {
@@ -45,7 +42,7 @@ export function useUserGroups(
     async () => {
       await fetch()
     },
-    { deep: true, immediate }
+    { deep: true, immediate: true }
   )
 
   return {
@@ -55,4 +52,4 @@ export function useUserGroups(
   }
 }
 
-export default useUserGroups
+export default useTags


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/28

Relates to:
- https://github.com/icefoganalytics/internal-data-portal/issues/7
- [0001, Data Modeling, 2024-01-05](https://docs.google.com/document/d/1Mdbl_Cy0BgKiq0DGdvOKUqJn-FdgbF0LSVykwf__FY8/edit?pli=1)
- [0002, UI Modeling, 2024-01-08](https://docs.google.com/document/d/1tP63Ob4XPBGlASPHVf1GnNb3hlIkybmWBqJDA61u3J0/edit)

# Context

## Dataset Description Manage Page - /dataset/:slug/description/manage

The edit version of the pages doesn’t seem to exist in the wireframes, so I would need another layer of User Role components to handle the different viewer types if I build this out. It might make more sense to just use auto-save for everything.

### Front-end routes

Various tabs on the same level as this component.

### Back-end routes

* /datasets/:id - GET 
* /datasets/:id - PATCH, update data set
* /tags - GET, list tags
* /tags - POST, create new tags
* /taggings - GET, list taggings
* /taggings - POST, associate existing tag with dataset
* /taggings/:id - DELETE, disassociate tag with data, orphaned tags should cleaned up
* /tags - POST, create new tag prior to associating it with a dataset via a tagging
* /users/search?email=...

### Components

* `BaseLayout.vue` - see previous definition
* `DatasetLayout.vue`
* `DatasetDescriptionManagePage.vue` - for data owner, sys admin and business analyst
    * `SubjectFormCard.vue`
        * Keywords - TagsCombobox.vue, multi select for tags probably needs a lot of very complex wiring to support mapping tags through taggings to dataset by id, and also supporting creation of new tags and linking them via taggings
    * `OwnerNotesFormCard.vue`
        * Text input field - Dataset#owner_notes

### Source Wireframe

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/68e8cbac-e574-4f8d-a048-631d877e8ecc)

# Implementation

Add tagging wiring that save automatically.
Add auto-save to the primary form as well and the owner notes for continuity.
Tags are created as needed, and destroyed when all references are lost.
Note: Opted not to set up autosave for "Owner" panel.

# Screenshots

[Screencast from 2024-02-13 12-28-32.webm](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/37a48145-6d76-4225-a6e5-b8a9276126d2)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a dataset if you don't have one from the /dashboard page.
5. After creation you will be redirected to the manage page for that dataset.
6. Check that all the fields of the "Data Description" form auto-save.
7. Check that the Subject keywords auto-save.
8. Check that the owner notes auto-save.
