### PR TITLE
Data Owner: Ability to Manage Dataset Fields

### DIFF
--- a/api/src/controllers/dataset-fields-controller.ts
+++ b/api/src/controllers/dataset-fields-controller.ts
@@ -2,10 +2,11 @@ import { WhereOptions } from "sequelize"
 import { isNil } from "lodash"
 
 import { Dataset, DatasetField } from "@/models"
-import { DatasetsPolicy } from "@/policies"
+import { DatasetFieldsPolicy } from "@/policies"
+import { DatasetFieldWithDataset } from "@/policies/dataset-fields-policy"
+import { CreateService, UpdateService } from "@/services/dataset-fields"
 
 import BaseController from "@/controllers/base-controller"
-import { CreateService } from "@/services/dataset-fields"
 
 export class DatasetFieldsController extends BaseController {
   async index() {
@@ -23,13 +24,13 @@ export class DatasetFieldsController extends BaseController {
   }
 
   async create() {
-    const dataset = await this.loadDataset()
-    if (isNil(dataset)) {
+    const datasetField = await this.buildDatasetField()
+    if (isNil(datasetField)) {
       return this.response.status(404).json({ message: "Dataset not found." })
     }
 
-    const policy = this.buildDatasetPolicy(dataset)
-    if (!policy.update()) {
+    const policy = this.buildPolicy(datasetField)
+    if (!policy.create()) {
       return this.response
         .status(403)
         .json({ message: "You are not authorized to create fields against this dataset." })
@@ -43,13 +44,59 @@ export class DatasetFieldsController extends BaseController {
     }
   }
 
-  private async loadDataset(): Promise<Dataset | null> {
-    const { datasetId } = this.request.body
-    return Dataset.findByPk(datasetId)
+  async update() {
+    const datasetField = await this.loadDatasetField()
+    if (isNil(datasetField)) {
+      return this.response.status(404).json({ message: "Dataset field not found." })
+    }
+
+    const policy = this.buildPolicy(datasetField)
+    if (!policy.update()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to update fields against this dataset." })
+    }
+
+    const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
+    try {
+      const updatedDatasetField = await UpdateService.perform(
+        datasetField,
+        permittedAttributes,
+        this.currentUser
+      )
+      return this.response.status(200).json({ datasetField: updatedDatasetField })
+    } catch (error) {
+      return this.response.status(422).json({ message: `Dataset field update failed: ${error}` })
+    }
   }
 
-  private buildDatasetPolicy(taggable: Dataset) {
-    return new DatasetsPolicy(this.currentUser, taggable)
+  private async buildDatasetField(): Promise<DatasetFieldWithDataset | null> {
+    const datasetField = DatasetField.build(this.request.body)
+    if (isNil(datasetField)) return null
+
+    const { datasetId } = this.request.body
+    if (isNil(datasetId)) return null
+
+    const dataset = await Dataset.findByPk(datasetId)
+    if (isNil(dataset)) return null
+
+    datasetField.dataset = dataset
+
+    // TODO: figure out how to make this type cast unneccessary
+    return datasetField as DatasetFieldWithDataset
+  }
+
+  private async loadDatasetField(): Promise<DatasetFieldWithDataset | null> {
+    const { datasetFieldId } = this.request.params
+    const datasetField = await DatasetField.findByPk(datasetFieldId, { include: ["dataset"] })
+    if (isNil(datasetField?.dataset)) return null
+
+    // TODO: figure out how to make this type cast unneccessary
+    return datasetField as DatasetFieldWithDataset
+  }
+
+  private buildPolicy(datasetField: DatasetFieldWithDataset) {
+    return new DatasetFieldsPolicy(this.currentUser, datasetField)
   }
 }
 

--- a/api/src/controllers/dataset-fields-controller.ts
+++ b/api/src/controllers/dataset-fields-controller.ts
@@ -4,7 +4,7 @@ import { isNil } from "lodash"
 import { Dataset, DatasetField } from "@/models"
 import { DatasetFieldsPolicy } from "@/policies"
 import { DatasetFieldWithDataset } from "@/policies/dataset-fields-policy"
-import { CreateService, UpdateService } from "@/services/dataset-fields"
+import { CreateService, DestroyService, UpdateService } from "@/services/dataset-fields"
 
 import BaseController from "@/controllers/base-controller"
 
@@ -33,11 +33,12 @@ export class DatasetFieldsController extends BaseController {
     if (!policy.create()) {
       return this.response
         .status(403)
-        .json({ message: "You are not authorized to create fields against this dataset." })
+        .json({ message: "You are not authorized to create fields for this dataset." })
     }
 
+    const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
     try {
-      const datasetField = await CreateService.perform(this.request.body, this.currentUser)
+      const datasetField = await CreateService.perform(permittedAttributes, this.currentUser)
       return this.response.status(201).json({ datasetField })
     } catch (error) {
       return this.response.status(422).json({ message: `Dataset field creation failed: ${error}` })
@@ -54,7 +55,7 @@ export class DatasetFieldsController extends BaseController {
     if (!policy.update()) {
       return this.response
         .status(403)
-        .json({ message: "You are not authorized to update fields against this dataset." })
+        .json({ message: "You are not authorized to update fields on this dataset." })
     }
 
     const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
@@ -67,6 +68,27 @@ export class DatasetFieldsController extends BaseController {
       return this.response.status(200).json({ datasetField: updatedDatasetField })
     } catch (error) {
       return this.response.status(422).json({ message: `Dataset field update failed: ${error}` })
+    }
+  }
+
+  async destroy() {
+    const datasetField = await this.loadDatasetField()
+    if (isNil(datasetField)) {
+      return this.response.status(404).json({ message: "Dataset field not found." })
+    }
+
+    const policy = this.buildPolicy(datasetField)
+    if (!policy.update()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to destroy fields on this dataset." })
+    }
+
+    try {
+      await DestroyService.perform(datasetField, this.currentUser)
+      return this.response.status(204).end()
+    } catch (error) {
+      return this.response.status(422).json({ message: `Dataset field destruction failed: ${error}` })
     }
   }
 

--- a/api/src/controllers/dataset-fields-controller.ts
+++ b/api/src/controllers/dataset-fields-controller.ts
@@ -1,8 +1,11 @@
 import { WhereOptions } from "sequelize"
+import { isNil } from "lodash"
 
-import { DatasetField } from "@/models"
+import { Dataset, DatasetField } from "@/models"
+import { DatasetsPolicy } from "@/policies"
 
 import BaseController from "@/controllers/base-controller"
+import { CreateService } from "@/services/dataset-fields"
 
 export class DatasetFieldsController extends BaseController {
   async index() {
@@ -17,6 +20,36 @@ export class DatasetFieldsController extends BaseController {
     })
 
     return this.response.json({ datasetFields, totalCount })
+  }
+
+  async create() {
+    const dataset = await this.loadDataset()
+    if (isNil(dataset)) {
+      return this.response.status(404).json({ message: "Dataset not found." })
+    }
+
+    const policy = this.buildDatasetPolicy(dataset)
+    if (!policy.update()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to create fields against this dataset." })
+    }
+
+    try {
+      const datasetField = await CreateService.perform(this.request.body, this.currentUser)
+      return this.response.status(201).json({ datasetField })
+    } catch (error) {
+      return this.response.status(422).json({ message: `Dataset field creation failed: ${error}` })
+    }
+  }
+
+  private async loadDataset(): Promise<Dataset | null> {
+    const { datasetId } = this.request.body
+    return Dataset.findByPk(datasetId)
+  }
+
+  private buildDatasetPolicy(taggable: Dataset) {
+    return new DatasetsPolicy(this.currentUser, taggable)
   }
 }
 

--- a/api/src/controllers/dataset-fields-controller.ts
+++ b/api/src/controllers/dataset-fields-controller.ts
@@ -1,0 +1,23 @@
+import { WhereOptions } from "sequelize"
+
+import { DatasetField } from "@/models"
+
+import BaseController from "@/controllers/base-controller"
+
+export class DatasetFieldsController extends BaseController {
+  async index() {
+    const where = this.query.where as WhereOptions<DatasetField>
+
+    const totalCount = await DatasetField.count({ where })
+    const datasetFields = await DatasetField.findAll({
+      where,
+      limit: this.pagination.limit,
+      offset: this.pagination.offset,
+      order: [["displayName", "ASC"]],
+    })
+
+    return this.response.json({ datasetFields, totalCount })
+  }
+}
+
+export default DatasetFieldsController

--- a/api/src/controllers/index.ts
+++ b/api/src/controllers/index.ts
@@ -1,4 +1,5 @@
 export { CurrentUserController } from "./current-user-controller"
+export { DatasetFieldsController } from "./dataset-fields-controller"
 export { DatasetsController } from "./datasets-controller"
 export { DatasetStewardshipsController } from "./dataset-stewardships-controller"
 export { TaggingsController } from "./taggings-controller"

--- a/api/src/db/migrations/2024.02.13T21.46.10.create-dataset-fields-table.ts
+++ b/api/src/db/migrations/2024.02.13T21.46.10.create-dataset-fields-table.ts
@@ -1,0 +1,77 @@
+import { DataTypes } from "sequelize"
+
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.createTable("dataset_fields", {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true,
+    },
+    dataset_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "datasets",
+        key: "id",
+      },
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    display_name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    data_type: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.STRING(1000),
+      allowNull: true,
+    },
+    note: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    created_at: {
+      type: MssqlSimpleTypes.DATETIME2(0),
+      allowNull: false,
+      defaultValue: MssqlSimpleTypes.NOW,
+    },
+    updated_at: {
+      type: MssqlSimpleTypes.DATETIME2(0),
+      allowNull: false,
+      defaultValue: MssqlSimpleTypes.NOW,
+    },
+    deleted_at: {
+      type: MssqlSimpleTypes.DATETIME2(0),
+      allowNull: true,
+    },
+  })
+
+  await queryInterface.addIndex("dataset_fields", ["dataset_id", "name"], {
+    unique: true,
+    name: "unique_dataset_fields_on_dataset_id_and_name",
+    where: {
+      deleted_at: null,
+    },
+  })
+
+  await queryInterface.addIndex("dataset_fields", ["dataset_id", "display_name"], {
+    unique: true,
+    name: "unique_dataset_fields_on_dataset_id_and_display_name",
+    where: {
+      deleted_at: null,
+    },
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.dropTable("dataset_fields")
+}

--- a/api/src/models/access-grant.ts
+++ b/api/src/models/access-grant.ts
@@ -120,7 +120,7 @@ export class AccessGrant extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(Dataset)
+    this.belongsTo(Dataset, { as: "dataset" })
     this.belongsTo(User, {
       foreignKey: "creatorId",
       as: "creator",

--- a/api/src/models/dataset-field.ts
+++ b/api/src/models/dataset-field.ts
@@ -16,6 +16,7 @@ import sequelize from "@/db/db-client"
 
 import Dataset from "@/models/dataset"
 
+// Keep in sync with web/src/api/dataset-fields-api.ts
 export enum DatasetFieldDataTypes {
   INTEGER = "integer",
   TEXT = "text",

--- a/api/src/models/dataset-field.ts
+++ b/api/src/models/dataset-field.ts
@@ -53,7 +53,9 @@ export class DatasetField extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(Dataset)
+    this.belongsTo(Dataset, {
+      as: "dataset",
+    })
   }
 }
 

--- a/api/src/models/dataset-field.ts
+++ b/api/src/models/dataset-field.ts
@@ -53,9 +53,7 @@ export class DatasetField extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(Dataset, {
-      as: "dataset",
-    })
+    this.belongsTo(Dataset, { as: "dataset" })
   }
 }
 

--- a/api/src/models/dataset-field.ts
+++ b/api/src/models/dataset-field.ts
@@ -1,0 +1,136 @@
+import {
+  Association,
+  BelongsToCreateAssociationMixin,
+  BelongsToGetAssociationMixin,
+  BelongsToSetAssociationMixin,
+  CreationOptional,
+  DataTypes,
+  ForeignKey,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+  NonAttribute,
+} from "sequelize"
+
+import sequelize from "@/db/db-client"
+
+import Dataset from "@/models/dataset"
+
+export enum DatasetFieldDataTypes {
+  INTEGER = "integer",
+  TEXT = "text",
+}
+
+export class DatasetField extends Model<
+  InferAttributes<DatasetField>,
+  InferCreationAttributes<DatasetField>
+> {
+  static readonly DataTypes = DatasetFieldDataTypes
+
+  declare id: CreationOptional<number>
+  declare datasetId: ForeignKey<Dataset>
+  declare name: string
+  declare displayName: string
+  declare dataType: DatasetFieldDataTypes
+  declare description: CreationOptional<string | null>
+  declare note: CreationOptional<string | null>
+  declare createdAt: CreationOptional<Date>
+  declare updatedAt: CreationOptional<Date>
+  declare deletedAt: CreationOptional<Date>
+
+  // https://sequelize.org/docs/v6/other-topics/typescript/#usage
+  // https://sequelize.org/docs/v6/core-concepts/assocs/#special-methodsmixins-added-to-instances
+  // https://sequelize.org/api/v7/types/_sequelize_core.index.belongstocreateassociationmixin
+  declare getDatasets: BelongsToGetAssociationMixin<Dataset>
+  declare setDatasets: BelongsToSetAssociationMixin<Dataset, Dataset["id"]>
+  declare createDataset: BelongsToCreateAssociationMixin<Dataset>
+
+  declare dataset?: NonAttribute<Dataset>
+
+  declare static associations: {
+    dataset: Association<DatasetField, Dataset>
+  }
+
+  static establishAssociations() {
+    this.belongsTo(Dataset)
+  }
+}
+
+DatasetField.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true,
+    },
+    datasetId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: Dataset,
+        key: "id",
+      },
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    displayName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    dataType: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        isIn: [Object.values(DatasetFieldDataTypes)],
+      },
+    },
+    description: {
+      type: DataTypes.STRING(1000),
+      allowNull: true,
+    },
+    note: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  },
+  {
+    sequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["dataset_id", "name"],
+        name: "unique_dataset_fields_on_dataset_id_and_name",
+        where: {
+          deleted_at: null,
+        },
+      },
+      {
+        unique: true,
+        fields: ["dataset_id", "display_name"],
+        name: "unique_dataset_fields_on_dataset_id_and_display_name",
+        where: {
+          deleted_at: null,
+        },
+      },
+    ],
+  }
+)
+
+export default DatasetField

--- a/api/src/models/dataset-stewardship.ts
+++ b/api/src/models/dataset-stewardship.ts
@@ -85,7 +85,7 @@ export class DatasetStewardship extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(Dataset)
+    this.belongsTo(Dataset, { as: "dataset" })
     this.belongsTo(User, { as: "owner" })
     this.belongsTo(User, { as: "support" })
     this.belongsTo(UserGroup, { as: "department" })

--- a/api/src/models/dataset.ts
+++ b/api/src/models/dataset.ts
@@ -28,6 +28,7 @@ import sequelize from "@/db/db-client"
 
 import AccessGrant from "@/models/access-grant"
 import AccessRequest from "@/models/access-request"
+import DatasetField from "@/models/dataset-field"
 import DatasetStewardship from "@/models/dataset-stewardship"
 import Tag from "@/models/tag"
 import Tagging, { TaggableTypes } from "@/models/tagging"
@@ -112,6 +113,17 @@ export class Dataset extends BaseModel<InferAttributes<Dataset>, InferCreationAt
   declare countAccessRequests: HasManyCountAssociationsMixin
   declare createAccessRequest: HasManyCreateAssociationMixin<AccessRequest>
 
+  declare getFields: HasManyGetAssociationsMixin<DatasetField>
+  declare setFields: HasManySetAssociationsMixin<DatasetField, DatasetField["id"]>
+  declare hasField: HasManyHasAssociationMixin<DatasetField, DatasetField["id"]>
+  declare hasFields: HasManyHasAssociationsMixin<DatasetField, DatasetField["id"]>
+  declare addField: HasManyAddAssociationMixin<DatasetField, DatasetField["id"]>
+  declare addFields: HasManyAddAssociationsMixin<DatasetField, DatasetField["id"]>
+  declare removeField: HasManyRemoveAssociationMixin<DatasetField, DatasetField["id"]>
+  declare removeFields: HasManyRemoveAssociationsMixin<DatasetField, DatasetField["id"]>
+  declare countFields: HasManyCountAssociationsMixin
+  declare createField: HasManyCreateAssociationMixin<DatasetField>
+
   declare getTaggings: HasManyGetAssociationsMixin<Tagging>
   declare setTaggings: HasManySetAssociationsMixin<Tagging, Tagging["taggableId"]>
   declare hasTagging: HasManyHasAssociationMixin<Tagging, Tagging["taggableId"]>
@@ -139,6 +151,7 @@ export class Dataset extends BaseModel<InferAttributes<Dataset>, InferCreationAt
   declare stewardship?: NonAttribute<DatasetStewardship>
   declare accessGrants?: NonAttribute<AccessGrant[]>
   declare accessRequests?: NonAttribute<AccessRequest[]>
+  declare fields?: NonAttribute<DatasetField[]>
   declare taggings?: NonAttribute<Tagging[]>
   declare tags?: NonAttribute<Tag[]>
 
@@ -146,6 +159,7 @@ export class Dataset extends BaseModel<InferAttributes<Dataset>, InferCreationAt
     accessGrants: Association<Dataset, AccessGrant>
     accessRequests: Association<Dataset, AccessRequest>
     creator: Association<Dataset, User>
+    fields: Association<Dataset, DatasetField>
     owner: Association<Dataset, User>
     stewardship: Association<Dataset, DatasetStewardship>
     taggings: Association<Dataset, Tagging>
@@ -168,6 +182,10 @@ export class Dataset extends BaseModel<InferAttributes<Dataset>, InferCreationAt
     this.hasMany(AccessRequest, {
       foreignKey: "datasetId",
       as: "accessRequests",
+    })
+    this.hasMany(DatasetField, {
+      foreignKey: "datasetId",
+      as: "fields",
     })
     this.hasMany(Tagging, {
       foreignKey: "taggableId",

--- a/api/src/models/index.ts
+++ b/api/src/models/index.ts
@@ -11,6 +11,7 @@ import { Tag } from "@/models/tag"
 import { Tagging } from "@/models/tagging"
 import { AccessGrant } from "@/models/access-grant"
 import { AccessRequest } from "@/models/access-request"
+import { DatasetField } from "@/models/dataset-field"
 
 // Estabilish associations between models, order likely matters
 Role.establishAssociations()
@@ -24,11 +25,13 @@ Tagging.establishAssociations()
 AccessGrant.establishAssociations()
 AccessRequest.establishAssociations()
 DatasetStewardship.establishAssociations()
+DatasetField.establishAssociations()
 
 export {
   AccessGrant,
   AccessRequest,
   Dataset,
+  DatasetField,
   DatasetStewardship,
   Role,
   StewardshipEvolution,

--- a/api/src/models/role.ts
+++ b/api/src/models/role.ts
@@ -47,7 +47,7 @@ export class Role extends Model<InferAttributes<Role>, InferCreationAttributes<R
   }
 
   static establishAssociations() {
-    this.belongsTo(User)
+    this.belongsTo(User, { as: "user" })
   }
 }
 

--- a/api/src/models/stewardship-evolution.ts
+++ b/api/src/models/stewardship-evolution.ts
@@ -69,7 +69,7 @@ export class StewardshipEvolution extends Model<
   }
 
   static establishAssociations() {
-    this.belongsTo(Dataset)
+    this.belongsTo(Dataset, { as: "dataset" })
     this.belongsTo(User, {
       foreignKey: "ownerId",
       as: "owner",

--- a/api/src/models/tag.ts
+++ b/api/src/models/tag.ts
@@ -50,7 +50,7 @@ export class Tag extends Model<InferAttributes<Tag>, InferCreationAttributes<Tag
   }
 
   static establishAssociations() {
-    this.hasMany(Tagging)
+    this.hasMany(Tagging, { as: "taggings" })
   }
 }
 

--- a/api/src/policies/dataset-fields-policy.ts
+++ b/api/src/policies/dataset-fields-policy.ts
@@ -25,8 +25,16 @@ export class DatasetFieldsPolicy extends BasePolicy<DatasetFieldWithDataset> {
     return this.datasetsPolicy.update()
   }
 
+  destroy(): boolean {
+    return this.datasetsPolicy.update()
+  }
+
   permittedAttributes(): Path[] {
     return ["name", "displayName", "dataType", "description", "note"]
+  }
+
+  permittedAttributesForCreate(): Path[] {
+    return ["datasetId", ...this.permittedAttributes()]
   }
 }
 

--- a/api/src/policies/dataset-fields-policy.ts
+++ b/api/src/policies/dataset-fields-policy.ts
@@ -1,0 +1,33 @@
+import { NonAttribute } from "sequelize"
+
+import { Path } from "@/utils/deep-pick"
+
+import { Dataset, DatasetField, User } from "@/models"
+
+import BasePolicy from "@/policies/base-policy"
+import DatasetsPolicy from "@/policies/datasets-policy"
+
+export type DatasetFieldWithDataset = DatasetField & { dataset: NonAttribute<Dataset> }
+
+export class DatasetFieldsPolicy extends BasePolicy<DatasetFieldWithDataset> {
+  private readonly datasetsPolicy: DatasetsPolicy
+
+  constructor(user: User, record: DatasetFieldWithDataset) {
+    super(user, record)
+    this.datasetsPolicy = new DatasetsPolicy(this.user, this.record.dataset)
+  }
+
+  create(): boolean {
+    return this.datasetsPolicy.update()
+  }
+
+  update(): boolean {
+    return this.datasetsPolicy.update()
+  }
+
+  permittedAttributes(): Path[] {
+    return ["name", "displayName", "dataType", "description", "note"]
+  }
+}
+
+export default DatasetFieldsPolicy

--- a/api/src/policies/index.ts
+++ b/api/src/policies/index.ts
@@ -1,4 +1,5 @@
+export { DatasetFieldsPolicy } from "./dataset-fields-policy"
 export { DatasetsPolicy } from "./datasets-policy"
 export { DatasetStewardshipsPolicy } from "./dataset-stewardships-policy"
-export { UsersPolicy } from "./users-policy"
 export { UserGroupsPolicy } from "./user-groups-policy"
+export { UsersPolicy } from "./users-policy"

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -57,7 +57,10 @@ router
   .route("/api/dataset-fields")
   .get(DatasetFieldsController.index)
   .post(DatasetFieldsController.create)
-router.route("/api/dataset-fields/:datasetFieldId").patch(DatasetFieldsController.update)
+router
+  .route("/api/dataset-fields/:datasetFieldId")
+  .patch(DatasetFieldsController.update)
+  .delete(DatasetFieldsController.destroy)
 
 router
   .route("/api/dataset-stewardships/:datasetStewardshipId")

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -57,6 +57,7 @@ router
   .route("/api/dataset-fields")
   .get(DatasetFieldsController.index)
   .post(DatasetFieldsController.create)
+router.route("/api/dataset-fields/:datasetFieldId").patch(DatasetFieldsController.update)
 
 router
   .route("/api/dataset-stewardships/:datasetStewardshipId")

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -53,7 +53,10 @@ router
   .get(DatasetsController.show)
   .patch(DatasetsController.update)
 
-router.route("/api/dataset-fields").get(DatasetFieldsController.index)
+router
+  .route("/api/dataset-fields")
+  .get(DatasetFieldsController.index)
+  .post(DatasetFieldsController.create)
 
 router
   .route("/api/dataset-stewardships/:datasetStewardshipId")

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -19,6 +19,7 @@ import { ensureAndAuthorizeCurrentUser } from "@/middlewares/authorization-middl
 
 import {
   CurrentUserController,
+  DatasetFieldsController,
   DatasetsController,
   DatasetStewardshipsController,
   QaScenarios,
@@ -51,6 +52,8 @@ router
   .route("/api/datasets/:datasetIdOrSlug")
   .get(DatasetsController.show)
   .patch(DatasetsController.update)
+
+router.route("/api/dataset-fields").get(DatasetFieldsController.index)
 
 router
   .route("/api/dataset-stewardships/:datasetStewardshipId")

--- a/api/src/services/dataset-fields/create-service.ts
+++ b/api/src/services/dataset-fields/create-service.ts
@@ -1,0 +1,50 @@
+import { isNil } from "lodash"
+
+import { DatasetField, User } from "@/models"
+
+import BaseService from "@/services/base-service"
+
+type Attributes = Partial<DatasetField>
+
+export class CreateService extends BaseService {
+  constructor(
+    private attributes: Attributes,
+    private currentUser: User
+  ) {
+    super()
+  }
+
+  async perform(): Promise<DatasetField> {
+    const { datasetId, name, displayName, dataType } = this.attributes
+
+    if (isNil(datasetId)) {
+      throw new Error("datasetId is required")
+    }
+
+    if (isNil(name)) {
+      throw new Error("name is required")
+    }
+
+    if (isNil(displayName)) {
+      throw new Error("displayName is required")
+    }
+
+    if (isNil(dataType)) {
+      throw new Error("dataType is required")
+    }
+
+    const datasetField = await DatasetField.create({
+      datasetId,
+      name,
+      displayName,
+      dataType,
+      ...this.attributes,
+    })
+
+    // TODO: log creating user
+
+    return datasetField
+  }
+}
+
+export default CreateService

--- a/api/src/services/dataset-fields/destroy-service.ts
+++ b/api/src/services/dataset-fields/destroy-service.ts
@@ -1,0 +1,22 @@
+import { DatasetField, User } from "@/models"
+
+import BaseService from "@/services/base-service"
+
+export class DestroyService extends BaseService {
+  constructor(
+    private datasetField: DatasetField,
+    private currentUser: User
+  ) {
+    super()
+  }
+
+  async perform(): Promise<void> {
+    await this.datasetField.destroy()
+
+    // TODO: log user action
+
+    return
+  }
+}
+
+export default DestroyService

--- a/api/src/services/dataset-fields/index.ts
+++ b/api/src/services/dataset-fields/index.ts
@@ -1,1 +1,2 @@
 export { CreateService } from "./create-service"
+export { UpdateService } from "./update-service"

--- a/api/src/services/dataset-fields/index.ts
+++ b/api/src/services/dataset-fields/index.ts
@@ -1,0 +1,1 @@
+export { CreateService } from "./create-service"

--- a/api/src/services/dataset-fields/index.ts
+++ b/api/src/services/dataset-fields/index.ts
@@ -1,2 +1,3 @@
 export { CreateService } from "./create-service"
 export { UpdateService } from "./update-service"
+export { DestroyService } from "./destroy-service"

--- a/api/src/services/dataset-fields/update-service.ts
+++ b/api/src/services/dataset-fields/update-service.ts
@@ -1,0 +1,25 @@
+import { DatasetField, User } from "@/models"
+
+import BaseService from "@/services/base-service"
+
+type Attributes = Partial<DatasetField>
+
+export class UpdateService extends BaseService {
+  constructor(
+    private datasetField: DatasetField,
+    private attributes: Attributes,
+    private currentUser: User
+  ) {
+    super()
+  }
+
+  async perform(): Promise<DatasetField> {
+    await this.datasetField.update(this.attributes)
+
+    // TODO: log creating user
+
+    return this.datasetField
+  }
+}
+
+export default UpdateService

--- a/api/src/services/dataset-fields/update-service.ts
+++ b/api/src/services/dataset-fields/update-service.ts
@@ -16,7 +16,7 @@ export class UpdateService extends BaseService {
   async perform(): Promise<DatasetField> {
     await this.datasetField.update(this.attributes)
 
-    // TODO: log creating user
+    // TODO: log user action
 
     return this.datasetField
   }

--- a/api/src/services/index.ts
+++ b/api/src/services/index.ts
@@ -1,3 +1,4 @@
+export * as DatasetFields from "./dataset-fields"
 export * as Datasets from "./datasets"
 export * as DatasetStewardships from "./dataset-stewardships"
 export * as Taggings from "./taggings"

--- a/web/src/api/dataset-fields-api.ts
+++ b/web/src/api/dataset-fields-api.ts
@@ -44,6 +44,15 @@ export const datasetFieldsApi = {
     const { data } = await http.post("/api/dataset-fields", attributes)
     return data
   },
+  async update(
+    datasetFieldId: number,
+    attributes: Partial<DatasetField>
+  ): Promise<{
+    datasetField: DatasetField
+  }> {
+    const { data } = await http.patch(`/api/dataset-fields/${datasetFieldId}`, attributes)
+    return data
+  },
 }
 
 export default datasetFieldsApi

--- a/web/src/api/dataset-fields-api.ts
+++ b/web/src/api/dataset-fields-api.ts
@@ -2,7 +2,8 @@ import http from "@/api/http-client"
 
 import { Dataset } from "@/api/datasets-api"
 
-export enum DataTypes {
+// Keep in sync with api/src/models/dataset-field.ts
+export enum DatasetFieldDataTypes {
   INTEGER = "integer",
   TEXT = "text",
 }
@@ -12,7 +13,7 @@ export type DatasetField = {
   datasetId: Dataset["id"]
   name: string
   displayName: string
-  dataType: DataTypes
+  dataType: DatasetFieldDataTypes
   description: string
   note: string
   createdAt: string
@@ -35,6 +36,12 @@ export const datasetFieldsApi = {
     const { data } = await http.get("/api/dataset-fields", {
       params: { where, page, perPage },
     })
+    return data
+  },
+  async create(attributes: Partial<DatasetField>): Promise<{
+    datasetField: DatasetField
+  }> {
+    const { data } = await http.post("/api/dataset-fields", attributes)
     return data
   },
 }

--- a/web/src/api/dataset-fields-api.ts
+++ b/web/src/api/dataset-fields-api.ts
@@ -53,6 +53,10 @@ export const datasetFieldsApi = {
     const { data } = await http.patch(`/api/dataset-fields/${datasetFieldId}`, attributes)
     return data
   },
+  async delete(datasetFieldId: number): Promise<void> {
+    const { data } = await http.delete(`/api/dataset-fields/${datasetFieldId}`)
+    return data
+  },
 }
 
 export default datasetFieldsApi

--- a/web/src/api/dataset-fields-api.ts
+++ b/web/src/api/dataset-fields-api.ts
@@ -1,0 +1,42 @@
+import http from "@/api/http-client"
+
+import { Dataset } from "@/api/datasets-api"
+
+export enum DataTypes {
+  INTEGER = "integer",
+  TEXT = "text",
+}
+
+export type DatasetField = {
+  id: number
+  datasetId: Dataset["id"]
+  name: string
+  displayName: string
+  dataType: DataTypes
+  description: string
+  note: string
+  createdAt: string
+  updatedAt: string
+}
+
+export const datasetFieldsApi = {
+  async list({
+    where,
+    page,
+    perPage,
+  }: {
+    where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
+    page?: number
+    perPage?: number
+  } = {}): Promise<{
+    datasetFields: DatasetField[]
+    totalCount: number
+  }> {
+    const { data } = await http.get("/api/dataset-fields", {
+      params: { where, page, perPage },
+    })
+    return data
+  },
+}
+
+export default datasetFieldsApi

--- a/web/src/components/dataset-fields/DatasetFieldCreateDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldCreateDialog.vue
@@ -1,0 +1,182 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500px"
+  >
+    <template #activator="{ props: dialogProps }">
+      <v-btn
+        color="primary"
+        v-bind="dialogProps"
+      >
+        Add Field
+      </v-btn>
+    </template>
+    <v-form
+      ref="form"
+      v-model="isValid"
+      @submit.prevent="createAndClose"
+    >
+      <v-card :loading="isLoading">
+        <v-card-title class="text-h5"> Create Field </v-card-title>
+
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.name"
+                :rules="[required]"
+                label="Field Name *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.displayName"
+                :rules="[required]"
+                label="Display Name *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.description"
+                label="Field Description"
+                rows="6"
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-select
+                v-model="datasetField.dataType"
+                :items="datasetFieldTypes"
+                :rules="[required]"
+                label="Data Type *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.note"
+                label="Notes"
+                rows="10"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="isLoading"
+            color="error"
+            @click="close"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            :loading="isLoading"
+            color="primary"
+            type="submit"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { nextTick, ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+
+import { VForm } from "vuetify/lib/components/index.mjs"
+
+import { required } from "@/utils/validators"
+import datasetFieldsApi, { DatasetField, DatasetFieldDataTypes } from "@/api/dataset-fields-api"
+import useSnack from "@/use/use-snack"
+
+const props = defineProps({
+  datasetId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const emit = defineEmits(["created"])
+
+const snack = useSnack()
+
+const datasetFieldTypes = Object.values(DatasetFieldDataTypes)
+const datasetField = ref<Partial<DatasetField>>({
+  datasetId: props.datasetId,
+})
+
+const router = useRouter()
+const route = useRoute()
+const showDialog = ref(route.query.showCreate === "true")
+const form = ref<InstanceType<typeof VForm> | null>(null)
+const isLoading = ref(false)
+const isValid = ref(false)
+
+watch(
+  () => props.datasetId,
+  () => {
+    resetDatasetField()
+  },
+  { immediate: true }
+)
+
+watch(
+  () => showDialog.value,
+  (value) => {
+    if (value) {
+      router.push({ query: { showCreate: "true" } })
+    } else {
+      router.push({ query: { showCreate: undefined } })
+    }
+  }
+)
+
+function close() {
+  showDialog.value = false
+  resetDatasetField()
+  form.value?.resetValidation()
+}
+
+async function createAndClose() {
+  if (!isValid.value) {
+    snack.notify("Please fill out all required fields", {
+      color: "error",
+    })
+    return
+  }
+
+  isLoading.value = true
+  try {
+    const { datasetField: newDatasetField } = await datasetFieldsApi.create(datasetField.value)
+    close()
+
+    await nextTick()
+    emit("created", newDatasetField.id)
+    snack.notify("Dataset field created", { color: "success" })
+  } catch (error) {
+    snack.notify(`Failed to create dataset field ${error}`, { color: "error" })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function resetDatasetField() {
+  datasetField.value = {
+    datasetId: props.datasetId,
+  }
+}
+</script>

--- a/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
@@ -110,9 +110,11 @@ const isLoading = ref(false)
 watch(
   () => showDialog.value,
   (value) => {
-    if (route.query.showDelete === datasetFieldId.value?.toString()) return
-
     if (value) {
+      if (route.query.showDelete === datasetFieldId.value?.toString()) {
+        return
+      }
+
       router.push({ query: { showDelete: datasetFieldId.value } })
     } else {
       router.push({ query: { showDelete: undefined } })

--- a/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
@@ -1,0 +1,160 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500px"
+  >
+    <v-form @submit.prevent="deleteAndClose">
+      <v-card :loading="isLoading">
+        <v-card-title class="text-h5"> Delete Field </v-card-title>
+
+        <v-card-text v-if="isNil(datasetField)">
+          <v-skeleton-loader type="text" />
+        </v-card-text>
+        <v-card-text v-else>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.name"
+                label="Field Name"
+                readonly
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.displayName"
+                label="Display Name"
+                readonly
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.description"
+                label="Field Description"
+                rows="6"
+                readonly
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-select
+                v-model="datasetField.dataType"
+                :items="datasetFieldTypes"
+                label="Data Type"
+                readonly
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.note"
+                label="Notes"
+                rows="10"
+                readonly
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="isLoading"
+            color="error"
+            @click="close"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            :loading="isLoading"
+            color="primary"
+            type="submit"
+          >
+            Delete
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { computed, nextTick, ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { isNil, cloneDeep } from "lodash"
+
+import { VForm } from "vuetify/lib/components/index.mjs"
+
+import datasetFieldsApi, { DatasetField, DatasetFieldDataTypes } from "@/api/dataset-fields-api"
+import useSnack from "@/use/use-snack"
+
+const emit = defineEmits(["deleted"])
+
+const snack = useSnack()
+
+const datasetFieldTypes = Object.values(DatasetFieldDataTypes)
+const datasetField = ref<DatasetField | null>(null)
+const datasetFieldId = computed(() => datasetField.value?.id)
+
+const router = useRouter()
+const route = useRoute()
+
+const showDialog = ref(false)
+const isLoading = ref(false)
+
+watch(
+  () => showDialog.value,
+  (value) => {
+    if (route.query.showDelete === datasetFieldId.value?.toString()) return
+
+    if (value) {
+      router.push({ query: { showDelete: datasetFieldId.value } })
+    } else {
+      router.push({ query: { showDelete: undefined } })
+    }
+  }
+)
+
+function show(newDatasetField: DatasetField) {
+  datasetField.value = cloneDeep(newDatasetField)
+  showDialog.value = true
+}
+
+function close() {
+  showDialog.value = false
+  resetDatasetField()
+}
+
+async function deleteAndClose() {
+  isLoading.value = true
+  try {
+    if (datasetFieldId.value === undefined) {
+      throw new Error("Dataset field id could not be found")
+    }
+
+    await datasetFieldsApi.delete(datasetFieldId.value)
+    close()
+
+    await nextTick()
+    emit("deleted", datasetFieldId.value)
+    snack.notify("Dataset field deleted", { color: "success" })
+  } catch (error) {
+    snack.notify(`Failed to delete dataset field ${error}`, { color: "error" })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function resetDatasetField() {
+  datasetField.value = null
+}
+
+defineExpose({
+  show,
+})
+</script>

--- a/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
@@ -65,14 +65,14 @@
           <v-spacer></v-spacer>
           <v-btn
             :loading="isLoading"
-            color="error"
+            color="primary"
             @click="close"
           >
             Cancel
           </v-btn>
           <v-btn
             :loading="isLoading"
-            color="primary"
+            color="error"
             type="submit"
           >
             Delete

--- a/web/src/components/dataset-fields/DatasetFieldEditDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldEditDialog.vue
@@ -1,0 +1,176 @@
+<template>
+  <v-dialog
+    v-model="showDialog"
+    max-width="500px"
+  >
+    <v-form
+      ref="form"
+      v-model="isValid"
+      @submit.prevent="updateAndClose"
+    >
+      <v-card :loading="isLoading">
+        <v-card-title class="text-h5"> Edit Field </v-card-title>
+
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.name"
+                :rules="[required]"
+                label="Field Name *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-text-field
+                v-model="datasetField.displayName"
+                :rules="[required]"
+                label="Display Name *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.description"
+                label="Field Description"
+                rows="6"
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-select
+                v-model="datasetField.dataType"
+                :items="datasetFieldTypes"
+                :rules="[required]"
+                label="Data Type *"
+                required
+              />
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col>
+              <v-textarea
+                v-model="datasetField.note"
+                label="Notes"
+                rows="10"
+              />
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn
+            :loading="isLoading"
+            color="error"
+            @click="close"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            :loading="isLoading"
+            color="primary"
+            type="submit"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { computed, nextTick, ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
+import { cloneDeep } from "lodash"
+
+import { VForm } from "vuetify/lib/components/index.mjs"
+
+import { required } from "@/utils/validators"
+import datasetFieldsApi, { DatasetField, DatasetFieldDataTypes } from "@/api/dataset-fields-api"
+import useSnack from "@/use/use-snack"
+
+const emit = defineEmits(["saved"])
+
+const snack = useSnack()
+
+const datasetFieldTypes = Object.values(DatasetFieldDataTypes)
+const datasetField = ref<Partial<DatasetField>>({})
+const datasetFieldId = computed(() => datasetField.value.id)
+
+const router = useRouter()
+const route = useRoute()
+
+const showDialog = ref(false)
+const form = ref<InstanceType<typeof VForm> | null>(null)
+const isLoading = ref(false)
+const isValid = ref(false)
+
+watch(
+  () => showDialog.value,
+  (value) => {
+    if (route.query.showEdit === datasetFieldId.value?.toString()) return
+
+    if (value) {
+      router.push({ query: { showEdit: datasetFieldId.value } })
+    } else {
+      router.push({ query: { showEdit: undefined } })
+    }
+  }
+)
+
+function show(newDatasetField: DatasetField) {
+  datasetField.value = cloneDeep(newDatasetField)
+  showDialog.value = true
+}
+
+function close() {
+  showDialog.value = false
+  resetDatasetField()
+  form.value?.resetValidation()
+}
+
+async function updateAndClose() {
+  if (!isValid.value) {
+    snack.notify("Please fill out all required fields", {
+      color: "error",
+    })
+    return
+  }
+
+  isLoading.value = true
+  try {
+    if (datasetFieldId.value === undefined) {
+      throw new Error("Dataset field id could not be found")
+    }
+
+    const { datasetField: newDatasetField } = await datasetFieldsApi.update(
+      datasetFieldId.value,
+      datasetField.value
+    )
+    close()
+
+    await nextTick()
+    emit("saved", newDatasetField.id)
+    snack.notify("Dataset field saved", { color: "success" })
+  } catch (error) {
+    snack.notify(`Failed to save dataset field ${error}`, { color: "error" })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function resetDatasetField() {
+  datasetField.value = {}
+}
+
+defineExpose({
+  show,
+})
+</script>

--- a/web/src/components/dataset-fields/DatasetFieldEditDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldEditDialog.vue
@@ -115,9 +115,11 @@ const isValid = ref(false)
 watch(
   () => showDialog.value,
   (value) => {
-    if (route.query.showEdit === datasetFieldId.value?.toString()) return
-
     if (value) {
+      if (route.query.showEdit === datasetFieldId.value?.toString()) {
+        return
+      }
+
       router.push({ query: { showEdit: datasetFieldId.value } })
     } else {
       router.push({ query: { showEdit: undefined } })

--- a/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
+++ b/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-data-table
+  <v-data-table-server
     v-model:items-per-page="itemsPerPage"
     v-model:page="page"
     :headers="headers"
@@ -38,7 +38,7 @@
         ></v-btn>
       </div>
     </template>
-  </v-data-table>
+  </v-data-table-server>
 </template>
 
 <script lang="ts" setup>

--- a/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
+++ b/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
@@ -82,7 +82,7 @@ const editDialog = ref<InstanceType<typeof DatasetFieldEditDialog> | null>(null)
 const deleteDialog = ref<InstanceType<typeof DatasetFieldDeleteDialog> | null>(null)
 
 function showDeleteDialog(datasetField: DatasetField) {
-  deleteDialog.value.show(datasetField)
+  deleteDialog.value?.show(datasetField)
 }
 
 function showEditDialog(datasetField: DatasetField) {

--- a/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
+++ b/web/src/components/dataset-fields/DatasetFieldsEditTable.vue
@@ -30,9 +30,10 @@
         <v-btn
           title="Delete"
           icon="mdi-delete"
-          size="small"
+          size="x-small"
           class="ml-2"
           color="error"
+          variant="outlined"
           @click="showDeleteDialog(item)"
         ></v-btn>
       </div>
@@ -48,6 +49,7 @@ import { isNil } from "lodash"
 import useDatasetFields, { DatasetField } from "@/use/use-dataset-fields"
 
 import DatasetFieldEditDialog from "@/components/dataset-fields/DatasetFieldEditDialog.vue"
+import DatasetFieldDeleteDialog from "@/components/dataset-fields/DatasetFieldDeleteDialog.vue"
 
 const props = defineProps({
   datasetId: {
@@ -103,12 +105,27 @@ function showEditDialogForRouteQuery() {
   showEditDialog(datasetField)
 }
 
+function showDeleteDialogForRouteQuery() {
+  if (typeof route.query.showDelete !== "string") return
+
+  const datasetFieldId = parseInt(route.query.showDelete)
+  if (isNaN(datasetFieldId)) return
+
+  const datasetField = datasetFields.value.find(
+    (datasetField) => datasetField.id === datasetFieldId
+  )
+  if (isNil(datasetField)) return
+
+  showDeleteDialog(datasetField)
+}
+
 watch(
   () => datasetFields.value,
   (datasetFields) => {
     if (datasetFields.length === 0) return
 
     showEditDialogForRouteQuery()
+    showDeleteDialogForRouteQuery()
   }
 )
 

--- a/web/src/components/dataset-fields/DatasetFieldsTable.vue
+++ b/web/src/components/dataset-fields/DatasetFieldsTable.vue
@@ -1,0 +1,63 @@
+<template>
+  <v-data-table
+    v-model:items-per-page="itemsPerPage"
+    v-model:page="page"
+    :headers="headers"
+    :items="datasetFields"
+    :items-length="totalCount"
+    :loading="isLoading"
+    class="elevation-1"
+  >
+  </v-data-table>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from "vue"
+
+const props = defineProps({
+  datasetId: {
+    type: Number,
+    required: true,
+  },
+})
+
+const headers = ref([
+  { title: "Field Name", key: "name" },
+  { title: "Display Name", key: "displayName" },
+  { title: "Field Description", key: "description" },
+  { title: "Data Type", key: "dataType" },
+  { title: "Notes", key: "note" },
+  { title: "", key: "actions" },
+])
+
+const itemsPerPage = ref(10)
+const page = ref(1)
+const datasetsQuery = computed(() => ({
+  where: {
+    datasetId: props.datasetId,
+  },
+  perPage: itemsPerPage.value,
+  page: page.value,
+}))
+
+// FAKE
+function useDatasetFields(query: any) {
+  console.log(`query:`, query)
+  return {
+    datasetFields: [],
+    totalCount: 0,
+    isLoading: ref(false),
+    fetch: async () => void 0,
+    refresh: async () => void 0,
+  }
+}
+
+const {
+  datasetFields,
+  totalCount,
+  isLoading,
+  refresh,
+} = useDatasetFields(datasetsQuery)
+
+defineExpose({ refresh })
+</script>

--- a/web/src/components/dataset-fields/DatasetFieldsTable.vue
+++ b/web/src/components/dataset-fields/DatasetFieldsTable.vue
@@ -14,6 +14,8 @@
 <script lang="ts" setup>
 import { computed, ref } from "vue"
 
+import useDatasetFields from "@/use/use-dataset-fields"
+
 const props = defineProps({
   datasetId: {
     type: Number,
@@ -40,24 +42,7 @@ const datasetsQuery = computed(() => ({
   page: page.value,
 }))
 
-// FAKE
-function useDatasetFields(query: any) {
-  console.log(`query:`, query)
-  return {
-    datasetFields: [],
-    totalCount: 0,
-    isLoading: ref(false),
-    fetch: async () => void 0,
-    refresh: async () => void 0,
-  }
-}
-
-const {
-  datasetFields,
-  totalCount,
-  isLoading,
-  refresh,
-} = useDatasetFields(datasetsQuery)
+const { datasetFields, totalCount, isLoading, refresh } = useDatasetFields(datasetsQuery)
 
 defineExpose({ refresh })
 </script>

--- a/web/src/components/datasets/DatasetsTable.vue
+++ b/web/src/components/datasets/DatasetsTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-data-table
+  <v-data-table-server
     v-model:items-per-page="itemsPerPage"
     v-model:page="page"
     :headers="headers"
@@ -50,7 +50,7 @@
       </template>
       <ColumnRouterLink :slug="slug" />
     </template>
-  </v-data-table>
+  </v-data-table-server>
 </template>
 
 <script lang="ts" setup>

--- a/web/src/layouts/DatasetLayout.vue
+++ b/web/src/layouts/DatasetLayout.vue
@@ -15,6 +15,7 @@
 
     <v-tabs>
       <DescriptionTab :slug="slug" />
+      <FieldsTab :slug="slug" />
       <!-- TODO: add in further tabs -->
     </v-tabs>
 
@@ -29,6 +30,7 @@ import { isNil } from "lodash"
 import { useDataset } from "@/use/use-dataset"
 
 import DescriptionTab from "@/layouts/dataset-layout/DescriptionTab.vue"
+import FieldsTab from "@/layouts/dataset-layout/FieldsTab.vue"
 
 const props = defineProps({
   slug: {

--- a/web/src/layouts/dataset-layout/FieldsTab.vue
+++ b/web/src/layouts/dataset-layout/FieldsTab.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tab :to="{ name: routeName, params: { slug } }"><h3>Description</h3></v-tab>
+  <v-tab :to="{ name: routeName, params: { slug } }"><h3>Fields</h3></v-tab>
 </template>
 
 <script lang="ts" setup>
@@ -20,9 +20,9 @@ const routeName = computed(() => {
   switch (route.name) {
     case "DatasetDescriptionManagePage":
     case "DatasetFieldsManagePage":
-      return "DatasetDescriptionManagePage"
+      return "DatasetFieldsManagePage"
     default:
-      return "DatasetDescriptionReadPage"
+      return "DatasetFieldsReadPage"
   }
 })
 </script>

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -1,5 +1,16 @@
 <template>
-  <h4 class="text-h4 mt-4">Fields</h4>
+  <h4 class="d-flex justify-space-between align-end text-h4 mt-4">
+    Fields
+
+    <v-skeleton-loader
+      v-if="isNil(dataset)"
+      type="button"
+    />
+    <DatasetFieldCreateDialog
+      v-else
+      :dataset-id="dataset.id"
+    />
+  </h4>
 
   <v-skeleton-loader
     v-if="isNil(dataset)"
@@ -21,6 +32,7 @@ import { useBreadcrumbs } from "@/use/use-breadcrumbs"
 import { useDataset } from "@/use/use-dataset"
 
 import DatasetFieldsTable from "@/components/dataset-fields/DatasetFieldsTable.vue"
+import DatasetFieldCreateDialog from "@/components/dataset-fields/DatasetFieldCreateDialog.vue"
 
 const props = defineProps({
   slug: {

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -18,7 +18,7 @@
     class="mt-6"
     type="table"
   />
-  <DatasetFieldsTable
+  <DatasetFieldsEditTable
     v-else
     ref="datasetFieldsTable"
     :dataset-id="dataset.id"
@@ -33,7 +33,7 @@ import { isNil } from "lodash"
 import { useBreadcrumbs } from "@/use/use-breadcrumbs"
 import { useDataset } from "@/use/use-dataset"
 
-import DatasetFieldsTable from "@/components/dataset-fields/DatasetFieldsTable.vue"
+import DatasetFieldsEditTable from "@/components/dataset-fields/DatasetFieldsEditTable.vue"
 import DatasetFieldCreateDialog from "@/components/dataset-fields/DatasetFieldCreateDialog.vue"
 
 const props = defineProps({
@@ -46,7 +46,7 @@ const props = defineProps({
 const { slug } = toRefs(props)
 const { dataset } = useDataset(slug)
 
-const datasetFieldsTable = ref<InstanceType<typeof DatasetFieldsTable> | null>(null)
+const datasetFieldsTable = ref<InstanceType<typeof DatasetFieldsEditTable> | null>(null)
 
 function refreshTable() {
   datasetFieldsTable.value?.refresh()

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -9,6 +9,7 @@
     <DatasetFieldCreateDialog
       v-else
       :dataset-id="dataset.id"
+      @created="refreshTable"
     />
   </h4>
 
@@ -19,13 +20,14 @@
   />
   <DatasetFieldsTable
     v-else
+    ref="datasetFieldsTable"
     :dataset-id="dataset.id"
     class="mt-6"
   />
 </template>
 
 <script setup lang="ts">
-import { toRefs } from "vue"
+import { ref, toRefs } from "vue"
 import { isNil } from "lodash"
 
 import { useBreadcrumbs } from "@/use/use-breadcrumbs"
@@ -43,6 +45,12 @@ const props = defineProps({
 
 const { slug } = toRefs(props)
 const { dataset } = useDataset(slug)
+
+const datasetFieldsTable = ref<InstanceType<typeof DatasetFieldsTable> | null>(null)
+
+function refreshTable() {
+  datasetFieldsTable.value?.refresh()
+}
 
 const { setBreadcrumbs } = useBreadcrumbs()
 

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -1,0 +1,47 @@
+<template>
+  TODO: build out dataset fields manage page.
+
+  <pre>{{ dataset }}</pre>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from "vue"
+
+import { useBreadcrumbs } from "@/use/use-breadcrumbs"
+import { useDataset } from "@/use/use-dataset"
+
+const props = defineProps({
+  slug: {
+    type: String,
+    required: true,
+  },
+})
+
+const { setBreadcrumbs } = useBreadcrumbs()
+
+setBreadcrumbs([
+  {
+    title: "Datasets",
+    to: {
+      name: "DatasetsPage",
+    },
+  },
+  {
+    title: "Fields",
+    to: {
+      name: "DatasetFieldsReadPage",
+      params: { slug: props.slug },
+    },
+  },
+  {
+    title: "Manage",
+    to: {
+      name: "DatasetFieldsManagePage",
+      params: { slug: props.slug },
+    },
+  },
+])
+
+const { slug } = toRefs(props)
+const { dataset } = useDataset(slug)
+</script>

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -1,14 +1,26 @@
 <template>
-  TODO: build out dataset fields manage page.
+  <h4>Fields</h4>
 
-  <pre>{{ dataset }}</pre>
+  <v-skeleton-loader
+    v-if="isNil(dataset)"
+    class="mt-6"
+    type="table"
+  />
+  <DatasetFieldsTable
+    v-else
+    :dataset-id="dataset.id"
+    class="mt-6"
+  />
 </template>
 
 <script setup lang="ts">
 import { toRefs } from "vue"
+import { isNil } from "lodash"
 
 import { useBreadcrumbs } from "@/use/use-breadcrumbs"
 import { useDataset } from "@/use/use-dataset"
+
+import DatasetFieldsTable from "@/components/dataset-fields/DatasetFieldsTable.vue"
 
 const props = defineProps({
   slug: {
@@ -16,6 +28,9 @@ const props = defineProps({
     required: true,
   },
 })
+
+const { slug } = toRefs(props)
+const { dataset } = useDataset(slug)
 
 const { setBreadcrumbs } = useBreadcrumbs()
 
@@ -41,7 +56,4 @@ setBreadcrumbs([
     },
   },
 ])
-
-const { slug } = toRefs(props)
-const { dataset } = useDataset(slug)
 </script>

--- a/web/src/pages/DatasetFieldsManagePage.vue
+++ b/web/src/pages/DatasetFieldsManagePage.vue
@@ -1,5 +1,5 @@
 <template>
-  <h4>Fields</h4>
+  <h4 class="text-h4 mt-4">Fields</h4>
 
   <v-skeleton-loader
     v-if="isNil(dataset)"

--- a/web/src/pages/DatasetFieldsReadPage.vue
+++ b/web/src/pages/DatasetFieldsReadPage.vue
@@ -1,0 +1,50 @@
+<template>
+  TODO: build out dataset fields page.
+
+  <v-btn
+    color="primary"
+    :to="{
+      name: 'DatasetFieldsManagePage',
+      params: { slug },
+    }"
+  >
+    Edit
+  </v-btn>
+
+  <pre>{{ dataset }}</pre>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from "vue"
+
+import { useBreadcrumbs } from "@/use/use-breadcrumbs"
+import { useDataset } from "@/use/use-dataset"
+
+const props = defineProps({
+  slug: {
+    type: String,
+    required: true,
+  },
+})
+
+const { setBreadcrumbs } = useBreadcrumbs()
+
+setBreadcrumbs([
+  {
+    title: "Datasets",
+    to: {
+      name: "DatasetsPage",
+    },
+  },
+  {
+    title: "Fields",
+    to: {
+      name: "DatasetFieldsReadPage",
+      params: { slug: props.slug },
+    },
+  },
+])
+
+const { slug } = toRefs(props)
+const { dataset } = useDataset(slug)
+</script>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -47,6 +47,18 @@ const routes: RouteRecordRaw[] = [
             component: () => import("@/pages/DatasetDescriptionManagePage.vue"),
             props: true,
           },
+          {
+            name: "DatasetFieldsReadPage",
+            path: "fields/read",
+            component: () => import("@/pages/DatasetFieldsReadPage.vue"),
+            props: true,
+          },
+          {
+            name: "DatasetFieldsManagePage",
+            path: "fields/manage",
+            component: () => import("@/pages/DatasetFieldsManagePage.vue"),
+            props: true,
+          }
         ],
       },
     ],

--- a/web/src/use/use-dataset-fields.ts
+++ b/web/src/use/use-dataset-fields.ts
@@ -1,0 +1,58 @@
+import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
+
+import datasetFieldsApi, { type DatasetField } from "@/api/dataset-fields-api"
+
+export { type DatasetField }
+
+export function useDatasetFields(
+  queryOptions: Ref<{
+    where?: Record<string, unknown>
+    page?: number
+    perPage?: number
+  }> = ref({})
+) {
+  const state = reactive<{
+    datasetFields: DatasetField[]
+    totalCount: number
+    isLoading: boolean
+    isErrored: boolean
+  }>({
+    datasetFields: [],
+    totalCount: 0,
+    isLoading: false,
+    isErrored: false,
+  })
+
+  async function fetch(): Promise<DatasetField[]> {
+    state.isLoading = true
+    try {
+      const { datasetFields, totalCount } = await datasetFieldsApi.list(unref(queryOptions))
+      state.isErrored = false
+      state.datasetFields = datasetFields
+      state.totalCount = totalCount
+      return datasetFields
+    } catch (error) {
+      console.error("Failed to fetch dataset fields:", error)
+      state.isErrored = true
+      throw error
+    } finally {
+      state.isLoading = false
+    }
+  }
+
+  watch(
+    () => unref(queryOptions),
+    async () => {
+      await fetch()
+    },
+    { deep: true, immediate: true }
+  )
+
+  return {
+    ...toRefs(state),
+    fetch,
+    refresh: fetch,
+  }
+}
+
+export default useDatasetFields


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/35

Relates to:
- [0001, Data Modeling, 2024-01-05](https://docs.google.com/document/d/1Mdbl_Cy0BgKiq0DGdvOKUqJn-FdgbF0LSVykwf__FY8/edit?pli=1)
- [0002, UI Modeling, 2024-01-08](https://docs.google.com/document/d/1tP63Ob4XPBGlASPHVf1GnNb3hlIkybmWBqJDA61u3J0/edit)
- https://github.com/icefoganalytics/internal-data-portal/issues/7

# Context

## Dataset Fields Manage Page - /dataset/:slug/fields/manage

### Front-end routes

Various tabs on the same level as this component.

### Back-end routes

* /api/dataset-fields - GET, list data set fields
* /api/dataset-fields - POST, create new data set fields
* /api/dataset-fields/:id - PATCH, update data set fields
* /api/dataset-fields/:id - DELETE, delete data set fields

### Components

* `BaseLayout.vue` - see previous definition
* `DatasetLayout.vue` - see previous definition
* `DatasetFieldsManagePage.vue`
    * support some kind of prefill operation if Dataset#subscription_url exists, likely very high complexity
    * `FieldsEditTable.vue`
        * Standard edit table, with top level create action, and per-record update/delete actions

### Source Wireframe

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/8779ef74-07ee-4a49-872e-b522a5a48524)

## DatasetField Model

`dataset_fields` table

### Fields

* `id`
* `dataset_id`
* `name`
* `display_name` - might be generated and non-editable
* `data_type` - an enum of things like `integer`, and `text`, not sure how many options are available.
* `description`
* `note`
* `created_at`
* `updated_at`
* `deleted_at`

### Relationships

* Belongs to a Dataset

# Implementation

Build a basic table with a top level create action and per-row update/delete actions.
Use modals for everything linked to query params, that trigger show/hide.

## Concerns

- In the future, it might be better to replace the modals with pages for each action as modals aren't very accessible, and provide a more limited experience.

# Screenshots

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/3f5f5c4e-9798-45aa-98e4-7f19bb95932d)

> save button is cut of in screenshot, but it _is_ there
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/3d5161b5-9161-4ba9-a1a9-303e615caf43)

> save button is cut of in screenshot, but it _is_ there
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/68d98078-42d9-4e44-8c41-3d75ba4a8b80)

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/aeb03d46-f1ab-4aaf-a191-e4ba90375204)
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/07529118-7b2f-4e4a-80c8-d6a7b7c52fff)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a dataset from the dashboard, or go to the http://localhost:8080/datasets page and click on a dataset to edit it.
5. Note that there is now a Fields tab. When in "read" mode the tabs direct to the "read" views, when in "manage" mode, the tabs redirect to the "manage" pages.
6. Check that the breadcrumbs redirect to the expected locations depending on the tab you have selected.
7. Click the fields tab, then click the "edit' button to go to the fields manage table.
8. Add some fields.
9. Edit some fields.
10. Delete some fields.
11. Add more than 10 fields, and check that table pagination works correctly.
12. Attempt to add a field with the same name as a previous field, but with a different field display name. This will fail informatively.
13. Repeat this with a duplicated display name, and a different field name. It will still fail.
