### PR TITLE
Switch Auth0 Client Id to Project Specific One

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
    ```bash
    VITE_AUTH0_DOMAIN=https://dev-0tc6bn14.eu.auth0.com
    VITE_AUTH0_AUDIENCE=testing
-   VITE_AUTH0_CLIENT_ID=mS8zklFSgatWX3v1OCQgVpEq5MixCm4k
+   VITE_AUTH0_CLIENT_ID=ZHjPOeCwYBov6eR1lxGOVYhYi4VPV8eU
    ```
 
 3. Go back to the top level directory.
@@ -268,7 +268,7 @@ Files:
 
    VITE_APPLICATION_NAME=Internal Data Portal
    VITE_AUTH0_DOMAIN=https://dev-0tc6bn14.eu.auth0.com
-   VITE_AUTH0_CLIENT_ID=mS8zklFSgatWX3v1OCQgVpEq5MixCm4k
+   VITE_AUTH0_CLIENT_ID=ZHjPOeCwYBov6eR1lxGOVYhYi4VPV8eU
    VITE_AUTH0_AUDIENCE=testing
 
    FRONTEND_URL=http://localhost:8080

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -11,7 +11,7 @@ x-default-environment: &default-environment
   FRONTEND_URL: "http://localhost:8080"
   VITE_APPLICATION_NAME: "Internal Data Portal"
   VITE_API_BASE_URL: "http://localhost:3000"
-  VITE_AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k"
+  VITE_AUTH0_CLIENT_ID: "ZHjPOeCwYBov6eR1lxGOVYhYi4VPV8eU"
   VITE_AUTH0_AUDIENCE: "testing"
   VITE_AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com"
   RELEASE_TAG: "${RELEASE_TAG:-development}"

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -13,7 +13,7 @@ const CONFIGS: {
   development: {
     API_BASE_URL: "http://localhost:3000",
     AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com",
-    AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k",
+    AUTH0_CLIENT_ID: "ZHjPOeCwYBov6eR1lxGOVYhYi4VPV8eU",
     AUTH0_AUDIENCE: "testing",
   },
   // Make sure that it's still possible to build locally in production mode
@@ -22,7 +22,7 @@ const CONFIGS: {
   production: {
     API_BASE_URL: "",
     AUTH0_DOMAIN: "https://dev-0tc6bn14.eu.auth0.com",
-    AUTH0_CLIENT_ID: "mS8zklFSgatWX3v1OCQgVpEq5MixCm4k",
+    AUTH0_CLIENT_ID: "ZHjPOeCwYBov6eR1lxGOVYhYi4VPV8eU",
     AUTH0_AUDIENCE: "testing",
   },
 }


### PR DESCRIPTION
# Context

Switch Auth0 Client Id to Project Specific One

# Implementation

Update client id to new auth0 client id.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a new user such as `marlen+idp+user@icefoganalytics.com.
> I used the pattern `email+project-acronym+user-role@domain.com
