### PR TITLE
Handle Users That Don't Exist In Yukon Government Directory

### DIFF
--- a/api/src/controllers/qa-scenarios/add-random-access-requests-controller.ts
+++ b/api/src/controllers/qa-scenarios/add-random-access-requests-controller.ts
@@ -104,7 +104,7 @@ export class AddRandomAccessRequestsController extends BaseController {
         firstName,
         lastName,
         position: faker.person.jobTitle(),
-        lastEmployeeDirectorySyncAt: faker.date.recent(),
+        lastSyncSuccessAt: faker.date.recent(),
       })
 
       await Role.create({

--- a/api/src/db/migrations/2024.03.07T00.26.44.add-sync-failure-at-concept-to-users-table.ts
+++ b/api/src/db/migrations/2024.03.07T00.26.44.add-sync-failure-at-concept-to-users-table.ts
@@ -1,0 +1,33 @@
+import type { Migration } from "@/db/umzug"
+import { MssqlSimpleTypes } from "@/db/utils/mssql-simple-types"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("users", "last_sync_success_at", {
+    type: MssqlSimpleTypes.DATETIME2(0),
+    allowNull: true,
+  })
+  await queryInterface.sequelize.query(/* sql */ `
+    UPDATE users
+    SET last_sync_success_at = last_employee_directory_sync_at
+  `)
+  await queryInterface.removeColumn("users", "last_employee_directory_sync_at")
+
+  await queryInterface.addColumn("users", "last_sync_failure_at", {
+    type: MssqlSimpleTypes.DATETIME2(0),
+    allowNull: true,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("users", "last_sync_failure_at")
+
+  await queryInterface.addColumn("users", "last_employee_directory_sync_at", {
+    type: MssqlSimpleTypes.DATETIME2(0),
+    allowNull: true,
+  })
+  await queryInterface.sequelize.query(/* sql */ `
+    UPDATE users
+    SET last_employee_directory_sync_at = last_sync_success_at
+  `)
+  await queryInterface.removeColumn("users", "last_sync_success_at")
+}

--- a/api/src/middlewares/authorization-middleware.ts
+++ b/api/src/middlewares/authorization-middleware.ts
@@ -32,7 +32,7 @@ async function findOrCreateUserFromAuth0Token(token: string): Promise<User> {
       firstName,
       lastName,
     })
-    console.log(`CREATED USER FOR ${email}: ${JSON.stringify(user.dataValues)}`)
+    console.log(`CREATED USER FOR User#${user.id} with ${email}`)
   }
 
   return user

--- a/api/src/middlewares/authorization-middleware.ts
+++ b/api/src/middlewares/authorization-middleware.ts
@@ -1,8 +1,11 @@
 import { type NextFunction, type Response } from "express"
 import { type Request as JwtRequest } from "express-jwt"
+import { isNil } from "lodash"
+
+import { User } from "@/models"
+import { Users } from "@/services"
 
 import auth0Integration, { Auth0PayloadError } from "@/integrations/auth0-integration"
-import { Role, User } from "@/models"
 
 export type AuthorizationRequest = JwtRequest & {
   currentUser?: User
@@ -11,28 +14,8 @@ export type AuthorizationRequest = JwtRequest & {
 async function findOrCreateUserFromAuth0Token(token: string): Promise<User> {
   const { auth0Subject, email, firstName, lastName } = await auth0Integration.getUserInfo(token)
 
-  // TODO: move to ensure user service
-  const [user, created] = await User.findOrCreate({
+  let user = await User.findOne({
     where: { auth0Subject },
-    defaults: {
-      auth0Subject,
-      email: email,
-      firstName,
-      lastName,
-    },
-  })
-  await Role.findOrCreate({
-    where: {
-      userId: user.id,
-      role: Role.Types.USER,
-    },
-    defaults: {
-      userId: user.id,
-      role: Role.Types.USER,
-    },
-  })
-
-  await user.reload({
     include: [
       "roles",
       {
@@ -42,7 +25,13 @@ async function findOrCreateUserFromAuth0Token(token: string): Promise<User> {
     ],
   })
 
-  if (created) {
+  if (isNil(user)) {
+    user = await Users.CreateService.perform({
+      auth0Subject,
+      email,
+      firstName,
+      lastName,
+    })
     console.log(`CREATED USER FOR ${email}: ${JSON.stringify(user.dataValues)}`)
   }
 

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -37,7 +37,7 @@ export class User extends BaseModel<InferAttributes<User>, InferCreationAttribut
   declare firstName: string | null
   declare lastName: string | null
   declare position: string | null
-  declare lastEmployeeDirectorySyncAt: Date | null
+  declare lastSyncSuccessAt: Date | null
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
   declare deletedAt: CreationOptional<Date>
@@ -156,12 +156,12 @@ export class User extends BaseModel<InferAttributes<User>, InferCreationAttribut
   }
 
   isTimeToSyncWithEmployeeDirectory(): NonAttribute<boolean> {
-    if (this.lastEmployeeDirectorySyncAt === null) {
+    if (this.lastSyncSuccessAt === null) {
       return true
     }
 
     const current = DateTime.utc()
-    const lastSyncDate = DateTime.fromJSDate(this.lastEmployeeDirectorySyncAt, { zone: "utc" })
+    const lastSyncDate = DateTime.fromJSDate(this.lastSyncSuccessAt, { zone: "utc" })
 
     return !current.hasSame(lastSyncDate, "day")
   }
@@ -195,7 +195,7 @@ User.init(
       type: DataTypes.STRING(100),
       allowNull: true,
     },
-    lastEmployeeDirectorySyncAt: {
+    lastSyncSuccessAt: {
       type: DataTypes.DATE,
       allowNull: true,
     },

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -38,6 +38,7 @@ export class User extends BaseModel<InferAttributes<User>, InferCreationAttribut
   declare lastName: string | null
   declare position: string | null
   declare lastSyncSuccessAt: Date | null
+  declare lastSyncFailureAt: Date | null
   declare createdAt: CreationOptional<Date>
   declare updatedAt: CreationOptional<Date>
   declare deletedAt: CreationOptional<Date>
@@ -155,7 +156,15 @@ export class User extends BaseModel<InferAttributes<User>, InferCreationAttribut
     return this.groupMembership?.unit
   }
 
+  /**
+   * NOTE: Blocks sync if there was a sync failure, requires manual intervention
+   * to re-enable syncing.
+   */
   isTimeToSyncWithEmployeeDirectory(): NonAttribute<boolean> {
+    if (this.lastSyncFailureAt !== null) {
+      return false
+    }
+
     if (this.lastSyncSuccessAt === null) {
       return true
     }
@@ -196,6 +205,10 @@ User.init(
       allowNull: true,
     },
     lastSyncSuccessAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    lastSyncFailureAt: {
       type: DataTypes.DATE,
       allowNull: true,
     },

--- a/api/src/serializers/datasets/show-serializer.ts
+++ b/api/src/serializers/datasets/show-serializer.ts
@@ -37,7 +37,6 @@ export class ShowSerializer extends BaseSerializer<Dataset> {
           "headerValue",
           "jmesPathTransform",
         ]),
-        visualizationControl: this.record.visualizationControl,
       })
     }
 
@@ -73,6 +72,7 @@ export class ShowSerializer extends BaseSerializer<Dataset> {
       owner: this.record.owner,
       stewardship: this.record.stewardship,
       tags: this.record.tags,
+      visualizationControl: this.record.visualizationControl,
 
       // magic fields
       currentUserAccessGrant,

--- a/api/src/serializers/user-serializers.ts
+++ b/api/src/serializers/user-serializers.ts
@@ -37,7 +37,7 @@ export class UserSerializers extends BaseSerializer<User> {
         "firstName",
         "lastName",
         "position",
-        "lastEmployeeDirectorySyncAt",
+        "lastSyncSuccessAt",
         "createdAt",
         "updatedAt",
       ]),

--- a/api/src/services/user-groups/yukon-government-directory-sync-service.ts
+++ b/api/src/services/user-groups/yukon-government-directory-sync-service.ts
@@ -16,7 +16,7 @@ export class YukonGovernmentDirectorySyncService extends BaseService {
         const isDivision = branch === null && unit === null
         const isBranch = unit === null
 
-        let [userGroup1] = await UserGroup.findOrCreate({
+        const [userGroup1] = await UserGroup.findOrCreate({
           where: {
             name: department,
             type: UserGroupTypes.DEPARTMENT,

--- a/api/src/services/users/create-service.ts
+++ b/api/src/services/users/create-service.ts
@@ -1,0 +1,151 @@
+import { isEmpty, isNil } from "lodash"
+
+import db, { Role, User, UserGroup, UserGroupMembership } from "@/models"
+
+import { Users, UserGroups } from "@/services"
+import BaseService from "@/services/base-service"
+
+type GroupMembershipAttributes = Partial<UserGroupMembership>
+type Attributes = Partial<User> & {
+  groupMembershipAttributes?: GroupMembershipAttributes
+}
+
+export class CreateService extends BaseService {
+  private attributes: Partial<User>
+  private groupMembershipAttributes?: GroupMembershipAttributes
+
+  constructor({ groupMembershipAttributes, ...attributes }: Attributes) {
+    super()
+    this.attributes = attributes
+    this.groupMembershipAttributes = groupMembershipAttributes
+  }
+
+  async perform(): Promise<User> {
+    const { auth0Subject, email, firstName, lastName, ...optionalAttributes } = this.attributes
+
+    if (isNil(auth0Subject) || isEmpty(auth0Subject)) {
+      throw new Error("auth0Subject is required")
+    }
+
+    if (isNil(email) || isEmpty(email)) {
+      throw new Error("email is required")
+    }
+
+    if (isEmpty(firstName)) {
+      throw new Error("firstName is required")
+    }
+
+    if (isEmpty(lastName)) {
+      throw new Error("lastName is required")
+    }
+
+    return db.transaction(async () => {
+      const user = await User.create({
+        auth0Subject,
+        email,
+        firstName,
+        lastName,
+        ...optionalAttributes,
+      })
+
+      await Role.create({
+        userId: user.id,
+        role: Role.Types.USER,
+      })
+
+      await this.ensureUserGroupMembership(user, this.groupMembershipAttributes)
+
+      return user.reload({
+        include: [
+          "roles",
+          {
+            association: "groupMembership",
+            include: ["department", "division", "branch", "unit"],
+          },
+        ],
+      })
+    })
+  }
+
+  private async ensureUserGroupMembership(
+    user: User,
+    groupMembershipAttributes?: GroupMembershipAttributes
+  ) {
+    if (!isEmpty(groupMembershipAttributes)) {
+      return UserGroupMembership.create({
+        userId: user.id,
+        ...groupMembershipAttributes,
+      })
+    }
+
+    await Users.YukonGovernmentDirectorySyncService.perform(user)
+
+    if (!isEmpty(user.groupMembership)) {
+      return user.groupMembership
+    }
+
+    const randomUserGroup = await UserGroup.findOne({
+      order: db.random(),
+    })
+
+    if (!isNil(randomUserGroup)) {
+      return this.establishGroupMembership(user, randomUserGroup)
+    }
+
+    await UserGroups.YukonGovernmentDirectorySyncService.perform()
+
+    const randomUserGroupTake2 = await UserGroup.findOne({
+      order: db.random(),
+    })
+    if (isNil(randomUserGroupTake2)) {
+      throw new Error("No user groups found")
+    }
+
+    return this.establishGroupMembership(user, randomUserGroupTake2)
+  }
+
+  private async establishGroupMembership(user: User, userGroup: UserGroup) {
+    if (userGroup.type === UserGroup.Types.DEPARTMENT) {
+      return UserGroupMembership.create({
+        userId: user.id,
+        departmentId: userGroup.id,
+      })
+    }
+
+    if (userGroup.type === UserGroup.Types.DIVISION) {
+      const department = await userGroup.getParent()
+
+      return UserGroupMembership.create({
+        userId: user.id,
+        departmentId: department?.id,
+        divisionId: userGroup.id,
+      })
+    }
+
+    if (userGroup.type === UserGroup.Types.BRANCH) {
+      const division = await userGroup.getParent()
+      const department = await division?.getParent()
+
+      return UserGroupMembership.create({
+        userId: user.id,
+        departmentId: department?.id,
+        divisionId: division?.id,
+        branchId: userGroup.id,
+      })
+    }
+
+    const branch = await userGroup.getParent()
+    const division = await branch?.getParent()
+    const department = await division?.getParent()
+
+    return UserGroupMembership.create({
+      userId: user.id,
+      departmentId: department?.id,
+      divisionId: division?.id,
+      branchId: branch?.id,
+      unitId: userGroup.id,
+    })
+  }
+}
+
+export default CreateService

--- a/api/src/services/users/create-service.ts
+++ b/api/src/services/users/create-service.ts
@@ -85,7 +85,8 @@ export class CreateService extends BaseService {
     }
 
     const randomUserGroup = await UserGroup.findOne({
-      order: db.random(),
+      // NOTE that sequelize.random() does not work correctly for MSSQL.
+      order: db.fn("NEWID"),
     })
 
     if (!isNil(randomUserGroup)) {

--- a/api/src/services/users/index.ts
+++ b/api/src/services/users/index.ts
@@ -1,1 +1,2 @@
+export { CreateService } from "./create-service"
 export { YukonGovernmentDirectorySyncService } from "./yukon-government-directory-sync-service"

--- a/api/src/services/users/yukon-government-directory-sync-service.ts
+++ b/api/src/services/users/yukon-government-directory-sync-service.ts
@@ -71,7 +71,7 @@ export class YukonGovernmentDirectorySyncService extends BaseService {
     } catch (error) {
       console.log("Failed to sync user with yukon government directory", error)
       await this.user.update({
-        lastEmployeeDirectorySyncAt: new Date(),
+        lastSyncSuccessAt: new Date(),
       })
       return this.user
     }

--- a/api/src/services/users/yukon-government-directory-sync-service.ts
+++ b/api/src/services/users/yukon-government-directory-sync-service.ts
@@ -59,6 +59,11 @@ export class YukonGovernmentDirectorySyncService extends BaseService {
         unitId: userGroup4?.id,
       })
 
+      this.user.update({
+        lastSyncSuccessAt: new Date(),
+        lastSyncFailureAt: null,
+      })
+
       return this.user.reload({
         include: [
           "roles",
@@ -71,7 +76,7 @@ export class YukonGovernmentDirectorySyncService extends BaseService {
     } catch (error) {
       console.log("Failed to sync user with yukon government directory", error)
       await this.user.update({
-        lastSyncSuccessAt: new Date(),
+        lastSyncFailureAt: new Date(),
       })
       return this.user
     }

--- a/api/tests/factories/user-factory.ts
+++ b/api/tests/factories/user-factory.ts
@@ -51,7 +51,7 @@ export const userFactory = BaseFactory.define<User, TransientParam>(
       firstName,
       lastName,
       position: faker.person.jobTitle(),
-      lastSyncSuccessAt: faker.date.recent(),
+      lastSyncFailureAt: faker.date.recent(),
     })
   }
 )

--- a/api/tests/factories/user-factory.ts
+++ b/api/tests/factories/user-factory.ts
@@ -51,7 +51,7 @@ export const userFactory = BaseFactory.define<User, TransientParam>(
       firstName,
       lastName,
       position: faker.person.jobTitle(),
-      lastEmployeeDirectorySyncAt: faker.date.recent(),
+      lastSyncSuccessAt: faker.date.recent(),
     })
   }
 )

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -4,7 +4,7 @@
     <!--
       NOTE: current user will always be defined when the authenticated router view loads.
     -->
-    <router-view v-else-if="isReady" />
+    <router-view v-else-if="isReady || isErrored" />
     <PageLoader
       v-else-if="isReadyAuth0"
       message="Fetching and syncing user"
@@ -18,12 +18,11 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { useAuth0 } from "@auth0/auth0-vue"
-import { useRoute } from "vue-router"
+import { useRoute, useRouter } from "vue-router"
 
 import useCurrentUser from "@/use/use-current-user"
-import useSnack from "@/use/use-snack"
 
 import PageLoader from "@/components/PageLoader.vue"
 import AppSnackbar from "@/components/AppSnackbar.vue"
@@ -38,8 +37,8 @@ const { isReady: isReadyCurrentUser, fetch } = useCurrentUser()
 
 const isReady = computed(() => isReadyAuth0.value && isReadyCurrentUser.value)
 
-const snack = useSnack()
-
+const isErrored = ref(false)
+const router = useRouter()
 watch(
   () => isReadyAuth0.value,
   async (newIsReadyAuth0) => {
@@ -51,9 +50,8 @@ watch(
         await fetch()
       } catch (error) {
         console.log("Failed to load current user:", error)
-        snack.notify("Failed to load current user", {
-          color: "error",
-        })
+        isErrored.value = true
+        router.push({ name: "UnauthorizedPage" })
       }
     }
   },

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -5,7 +5,14 @@
       NOTE: current user will always be defined when the authenticated router view loads.
     -->
     <router-view v-else-if="isReady" />
-    <PageLoader v-else />
+    <PageLoader
+      v-else-if="isReadyAuth0"
+      message="Fetching and syncing user"
+    />
+    <PageLoader
+      v-else
+      message="Checking authentication status ..."
+    />
     <AppSnackbar />
   </v-app>
 </template>
@@ -16,6 +23,8 @@ import { useAuth0 } from "@auth0/auth0-vue"
 import { useRoute } from "vue-router"
 
 import useCurrentUser from "@/use/use-current-user"
+import useSnack from "@/use/use-snack"
+
 import PageLoader from "@/components/PageLoader.vue"
 import AppSnackbar from "@/components/AppSnackbar.vue"
 
@@ -28,6 +37,8 @@ const isReadyAuth0 = computed(() => !isLoadingAuth0.value && isAuthenticated.val
 const { isReady: isReadyCurrentUser, fetch } = useCurrentUser()
 
 const isReady = computed(() => isReadyAuth0.value && isReadyCurrentUser.value)
+
+const snack = useSnack()
 
 watch(
   () => isReadyAuth0.value,
@@ -50,9 +61,10 @@ watch(
       try {
         await fetch()
       } catch (error) {
-        console.log("Failed to ensure current user:", error)
-        // Toast/snack Please contact support ...
-        // logout?
+        console.log("Failed to load current user:", error)
+        snack.notify("Failed to load current user", {
+          color: "error",
+        })
       }
     }
   },

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -47,17 +47,6 @@ watch(
     if (isUnauthenticatedRoute.value) return
 
     if (newIsReadyAuth0 === true) {
-      /*
-        TODO: avoid ensuring user as part of login pipeline
-        NOTE: isReadyAuth0 === is just after successful auth0 login
-        try to log in
-          If login fails,
-            try to create user
-          If creation succeeds,
-            use user
-          else
-            show error page
-      */
       try {
         await fetch()
       } catch (error) {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -25,7 +25,7 @@ const isUnauthenticatedRoute = computed(() => route.meta.requiresAuth === false)
 
 const { isLoading: isLoadingAuth0, isAuthenticated } = useAuth0()
 const isReadyAuth0 = computed(() => !isLoadingAuth0.value && isAuthenticated.value)
-const { isReady: isReadyCurrentUser, ensure } = useCurrentUser()
+const { isReady: isReadyCurrentUser, fetch } = useCurrentUser()
 
 const isReady = computed(() => isReadyAuth0.value && isReadyCurrentUser.value)
 
@@ -48,7 +48,7 @@ watch(
             show error page
       */
       try {
-        await ensure()
+        await fetch()
       } catch (error) {
         console.log("Failed to ensure current user:", error)
         // Toast/snack Please contact support ...

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -36,6 +36,17 @@ watch(
     if (isUnauthenticatedRoute.value) return
 
     if (newIsReadyAuth0 === true) {
+      /*
+        TODO: avoid ensuring user as part of login pipeline
+        NOTE: isReadyAuth0 === is just after successful auth0 login
+        try to log in
+          If login fails,
+            try to create user
+          If creation succeeds,
+            use user
+          else
+            show error page
+      */
       try {
         await ensure()
       } catch (error) {

--- a/web/src/components/PageLoader.vue
+++ b/web/src/components/PageLoader.vue
@@ -7,7 +7,16 @@
         class="mb-5"
         color="yg-blue"
       ></v-progress-circular>
-      <h1>Loading ...</h1>
+      <h1>{{ message }}</h1>
     </div>
   </div>
 </template>
+
+<script lang="ts" setup>
+defineProps({
+  message: {
+    type: String,
+    default: "Loading ...",
+  },
+})
+</script>

--- a/web/src/components/user-groups/UserGroupAutocomplete.vue
+++ b/web/src/components/user-groups/UserGroupAutocomplete.vue
@@ -18,6 +18,7 @@ export { UserGroupTypes } from "@/use/use-user-groups"
 <script setup lang="ts">
 import { computed } from "vue"
 
+import { MAX_PER_PAGE } from "@/api/base-api"
 import useUserGroups, { UserGroupTypes } from "@/use/use-user-groups"
 
 const props = withDefaults(
@@ -39,6 +40,8 @@ const userGroupsQuery = computed(() => {
       type: props.type,
       parentId: props.parentId,
     },
+    // TODO: replace max per page with search feature
+    perPage: MAX_PER_PAGE,
   }
 })
 const { userGroups } = useUserGroups(userGroupsQuery)

--- a/web/src/pages/UnauthorizedPage.vue
+++ b/web/src/pages/UnauthorizedPage.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-container class="text-center mt-16">
+    <h1>Unauthorized (401)</h1>
+    <p>Authentication failed. If you think this is an error, please contact support.</p>
+    <p>Alternatively, try logging out and signing in again.</p>
+    <v-btn
+      class="mt-6"
+      color="primary"
+      @click="logoutWithRedirect"
+      >Logout</v-btn
+    >
+    <hr />
+    <p>Site: {{ APPLICATION_NAME }}</p>
+    <p>Version: {{ releaseTag }}</p>
+    <p>Commit Hash: {{ gitCommitHash }}</p>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+import { onMounted, ref } from "vue"
+import { useAuth0 } from "@auth0/auth0-vue"
+
+import http from "@/api/http-client"
+
+import { APPLICATION_NAME } from "@/config"
+
+const { logout } = useAuth0()
+
+const releaseTag = ref("not-set")
+const gitCommitHash = ref("not-set")
+
+const isLoading = ref(true)
+
+onMounted(async () => {
+  await refresh()
+})
+
+function logoutWithRedirect() {
+  return logout({
+    logoutParams: {
+      // I would prefer to redirect to /sign-in here, but that doesn't seem to work?
+      returnTo: window.location.origin,
+    },
+  })
+}
+
+async function fetchVersion() {
+  return http
+    .get("/_status")
+    .then(({ data }) => {
+      releaseTag.value = data.RELEASE_TAG
+      gitCommitHash.value = data.GIT_COMMIT_HASH
+      return data
+    })
+    .catch((error: unknown) => {
+      console.error(`Error fetching version: ${error}`)
+    })
+}
+
+async function refresh() {
+  isLoading.value = true
+  try {
+    await fetchVersion()
+  } catch (error) {
+    console.error(`Error fetching version: ${error}`)
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<style scoped>
+body {
+  text-align: center;
+  padding-top: 100px;
+}
+hr {
+  margin-top: 30px;
+  margin-bottom: 30px;
+}
+</style>

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -101,6 +101,11 @@ const routes: RouteRecordRaw[] = [
     meta: { requiresAuth: false },
   },
   {
+    name: "UnauthorizedPage",
+    path: "/errors/unauthorized",
+    component: () => import("@/pages/UnauthorizedPage.vue"),
+  },
+  {
     name: "NotFoundPage",
     path: "/:pathMatch(.*)*",
     component: () => import("@/pages/NotFoundPage.vue"),


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/51

# Context

When login in as a user that doesn't match up with the Yukon Government directory, it creates a user that is missing their `groupMembership` record.

All users should have a groupMembership record created when the user is create.

Probably the quickest solution is to move the user creation logic from `findOrCreateUserFromAuth0Token` into a service that does these things. It will likely also need to load all users groups from YG if there aren't any. If there are user groups, it should assign a random group.

In the long run, and if this looks easy, I should move the user creation logic out of the authorization pipeline.
Currently _any_ API call could potentially create a User object as a side effect, and this is obviously _not good_.

# Implementation

Create users with the appropriate dependent tables via a standard user create service.
If they don't have a department, they get assigned to the `Unassigned` department.
Add an authentication failure page, this page will be triggered if the app goes down.

# Screenshots

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/9cfef7a6-5e2a-4edf-8e6a-44747878fd7b)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the app and log out if you are logged in. You will be redirected to the login page.
5. Click the "sign up" link instead of logging in.
6. Create a new account such as <your-name>+<app-acronym>+<user-role>@icefoganalytics.com
7. Check that you can log in to the app, and view the datasets.
8. Switch your user role to something better, and create a dataset.
