### PR TITLE
Fix Testing Account With Missing User Group Membership

### DIFF
--- a/api/src/db/migrations/2024.03.08T16.18.17.fix-testing-account-with-missing-user-group-membership.ts
+++ b/api/src/db/migrations/2024.03.08T16.18.17.fix-testing-account-with-missing-user-group-membership.ts
@@ -1,0 +1,38 @@
+import { isEmpty, isNil } from "lodash"
+
+import { User, UserGroup, UserGroupMembership } from "@/models"
+
+import type { Migration } from "@/db/umzug"
+import { DEFAULT_ORDER } from "@/models/user-groups"
+
+export const up: Migration = async () => {
+  const user = await User.findOne({
+    where: { email: "michael@icefoganalytics.com" },
+    include: "groupMembership",
+  })
+
+  if (isNil(user)) return
+
+  if (!isEmpty(user.groupMembership)) return
+
+  const [defaultGroup] = await UserGroup.findOrCreate({
+    where: {
+      type: UserGroup.Types.DEPARTMENT,
+      name: "Unassigned",
+    },
+    defaults: {
+      name: "Unassigned",
+      type: UserGroup.Types.DEPARTMENT,
+      order: DEFAULT_ORDER,
+    },
+  })
+
+  return UserGroupMembership.create({
+    userId: user.id,
+    departmentId: defaultGroup.id,
+  })
+}
+
+export const down: Migration = async () => {
+  // nop
+}


### PR DESCRIPTION
# Context

:butterfly: Fix testing account with missing user group membership

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Run the migration via `dev migrate up`
