### PR TITLE
Make all Readonly Fields in the App Use a mdi-lock prepend-icon

### DIFF
--- a/web/src/components/access-grants/AccessGrantDeleteDialog.vue
+++ b/web/src/components/access-grants/AccessGrantDeleteDialog.vue
@@ -15,6 +15,7 @@
             <v-col>
               <AccessGrantGrantLevelSelect
                 v-model="accessGrant.grantLevel"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>
@@ -23,6 +24,7 @@
             <v-col>
               <AccessGrantAccessTypeSelect
                 v-model="accessGrant.accessType"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>
@@ -33,6 +35,7 @@
                 :model-value="accessGrant.supportId"
                 label="Request Email"
                 attribute="email"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>

--- a/web/src/components/access-requests/AccessRequestApproveDialog.vue
+++ b/web/src/components/access-requests/AccessRequestApproveDialog.vue
@@ -17,6 +17,7 @@
                 :model-value="accessRequest.requestorId"
                 label="Name"
                 attribute="displayName"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -27,6 +28,7 @@
               <v-text-field
                 :model-value="accessRequest.requestorDepartmentName"
                 label="Department"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -37,6 +39,7 @@
               <v-text-field
                 :model-value="accessRequest.projectName"
                 label="Request on Behalf Of (Program/App)"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -47,6 +50,7 @@
               <v-textarea
                 :model-value="accessRequest.projectDescription"
                 label="Project Description"
+                append-inner-icon="mdi-lock"
                 rows="5"
                 variant="outlined"
                 readonly

--- a/web/src/components/access-requests/AccessRequestDenyDialog.vue
+++ b/web/src/components/access-requests/AccessRequestDenyDialog.vue
@@ -17,6 +17,7 @@
                 :model-value="accessRequest.requestorId"
                 label="Name"
                 attribute="displayName"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -27,6 +28,7 @@
               <v-text-field
                 :model-value="accessRequest.requestorDepartmentName"
                 label="Department"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -37,6 +39,7 @@
               <v-text-field
                 :model-value="accessRequest.projectName"
                 label="Request on Behalf Of (Program/App)"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -47,6 +50,7 @@
               <v-textarea
                 :model-value="accessRequest.projectDescription"
                 label="Project Description"
+                append-inner-icon="mdi-lock"
                 rows="5"
                 variant="outlined"
                 readonly

--- a/web/src/components/access-requests/AccessRequestRevokeDialog.vue
+++ b/web/src/components/access-requests/AccessRequestRevokeDialog.vue
@@ -17,6 +17,7 @@
                 :model-value="accessRequest.requestorId"
                 label="Name"
                 attribute="displayName"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -27,6 +28,7 @@
               <v-text-field
                 :model-value="accessRequest.requestorDepartmentName"
                 label="Department"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -37,6 +39,7 @@
               <v-text-field
                 :model-value="accessRequest.projectName"
                 label="Request on Behalf Of (Program/App)"
+                append-inner-icon="mdi-lock"
                 variant="outlined"
                 readonly
               />
@@ -47,6 +50,7 @@
               <v-textarea
                 :model-value="accessRequest.projectDescription"
                 label="Project Description"
+                append-inner-icon="mdi-lock"
                 rows="5"
                 variant="outlined"
                 readonly

--- a/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldDeleteDialog.vue
@@ -16,6 +16,7 @@
               <v-text-field
                 v-model="datasetField.name"
                 label="Field Name"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>
@@ -25,6 +26,7 @@
               <v-text-field
                 v-model="datasetField.displayName"
                 label="Display Name"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>
@@ -34,6 +36,7 @@
               <v-textarea
                 v-model="datasetField.description"
                 label="Field Description"
+                append-inner-icon="mdi-lock"
                 rows="6"
                 readonly
               />
@@ -45,6 +48,7 @@
                 v-model="datasetField.dataType"
                 :items="datasetFieldTypes"
                 label="Data Type"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>
@@ -55,6 +59,7 @@
                 v-model="datasetField.note"
                 label="Notes"
                 rows="10"
+                append-inner-icon="mdi-lock"
                 readonly
               />
             </v-col>

--- a/web/src/components/datasets/DataDescriptionCard.vue
+++ b/web/src/components/datasets/DataDescriptionCard.vue
@@ -85,6 +85,7 @@
               :model-value="dataset.name"
               label="Name"
               variant="outlined"
+              append-inner-icon="mdi-lock"
               readonly
             />
           </v-col>
@@ -97,6 +98,7 @@
             <v-textarea
               :model-value="dataset.description"
               label="Description"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               rows="6"
               readonly
@@ -121,6 +123,7 @@
             <v-textarea
               :model-value="dataset.termsOfUse"
               label="Terms of Use"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               rows="4"
               readonly
@@ -128,6 +131,7 @@
             <v-textarea
               :model-value="dataset.credits"
               label="Credits"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               rows="4"
               readonly

--- a/web/src/components/datasets/OwnerCard.vue
+++ b/web/src/components/datasets/OwnerCard.vue
@@ -20,6 +20,7 @@
             <UserAttributeTextField
               :model-value="datasetStewardship.ownerId"
               label="Owner Name"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -32,6 +33,7 @@
               :model-value="datasetStewardship.ownerId"
               label="Owner Position"
               attribute="position"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -46,6 +48,7 @@
               :model-value="datasetStewardship.supportId"
               label="Support Name"
               attribute="displayName"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -58,6 +61,7 @@
               :model-value="datasetStewardship.supportId"
               label="Support Email"
               attribute="email"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -72,6 +76,7 @@
               :model-value="datasetStewardship.supportId"
               label="Support Position"
               attribute="position"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -90,6 +95,7 @@
               item-value="id"
               item-title="name"
               label="Department"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -106,6 +112,7 @@
               item-value="id"
               item-title="name"
               label="Division"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -124,6 +131,7 @@
               item-value="id"
               item-title="name"
               label="Branch"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />
@@ -140,6 +148,7 @@
               item-value="id"
               item-title="name"
               label="Unit"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               readonly
             />

--- a/web/src/components/datasets/SubjectCard.vue
+++ b/web/src/components/datasets/SubjectCard.vue
@@ -9,6 +9,7 @@
             <TagsCombobox
               :model-value="selectedTags"
               label="Keywords"
+              append-inner-icon="mdi-lock"
               variant="outlined"
               :closable-chips="false"
               readonly

--- a/web/src/components/users/UserAttributeTextField.vue
+++ b/web/src/components/users/UserAttributeTextField.vue
@@ -31,6 +31,10 @@ const { modelValue: userId } = toRefs(props)
 const { user, isLoading } = useUser(userId)
 
 const fieldValue = computed(() => {
+  if (isNil(props.modelValue)) {
+    return ""
+  }
+
   if (isLoading.value) {
     return "loading..."
   }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/52

# Context

See https://github.com/icefoganalytics/travel-authorization/issues/154#issuecomment-1960295021

# Implementation

Add lock icon to all read-only text and select fields.
Did not add lock icon to read-only checkbox fields as I'm not sure what UI to use.

# Screenshots

New
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/94257fa1-a966-43af-b4de-8f0497bf5001)

Old
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/278b0004-489f-4e88-bd27-478528a43f6b)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Navigate around the app and note that all readonly text and select fields have lock icons in them.
