### PR TITLE
UX: Harmonize Dataset Description Manage Owner Section To Use AutoSave Instead of Using a Save Button

### DIFF
--- a/web/src/components/datasets/OwnerFormCard.vue
+++ b/web/src/components/datasets/OwnerFormCard.vue
@@ -1,6 +1,12 @@
 <template>
   <v-card>
-    <v-card-title>Owner</v-card-title>
+    <v-card-title class="d-flex justify-space-between align-center">
+      Owner
+      <SaveStateProgress
+        :saving="isLoading"
+        @click="saveAndNotify"
+      />
+    </v-card-title>
 
     <v-card-text>
       <!-- TODO: make the skeleton loader an external component that matches the form -->
@@ -11,7 +17,6 @@
       <v-form
         v-else
         class="d-flex flex-column mt-6"
-        @submit.prevent="saveWrapper"
       >
         <v-row>
           <v-col
@@ -191,16 +196,6 @@
             />
           </v-col>
         </v-row>
-        <div class="d-flex justify-end">
-          <v-btn
-            :loading="isLoading"
-            type="submit"
-            color="primary"
-            variant="outlined"
-          >
-            Save
-          </v-btn>
-        </div>
       </v-form>
     </v-card-text>
   </v-card>
@@ -219,6 +214,8 @@ import useDataset from "@/use/use-dataset"
 import useSnack from "@/use/use-snack"
 import useUserGroups from "@/use/use-user-groups"
 import useUsers from "@/use/use-users"
+
+import SaveStateProgress from "@/components/SaveStateProgress.vue"
 
 const props = defineProps({
   slug: {
@@ -308,9 +305,11 @@ async function updateOwner(newOwnerId: number | null) {
   await updateDivision(newDivisionId)
   await updateBranch(newBranchId)
   await updateUnit(newUnitId)
+
+  await saveAndNotify()
 }
 
-function updateSupport(supportId: number | null) {
+async function updateSupport(supportId: number | null) {
   if (isNil(datasetStewardship.value)) {
     throw new Error("Dataset stewardship is not defined")
   }
@@ -320,6 +319,8 @@ function updateSupport(supportId: number | null) {
   }
 
   datasetStewardship.value.supportId = supportId
+
+  await saveAndNotify()
 }
 
 function clearDivision() {
@@ -359,6 +360,8 @@ async function updateDepartment(newDepartmentId: number | null) {
 
   datasetStewardship.value.departmentId = newDepartmentId
   clearDivision()
+
+  await saveAndNotify()
 }
 
 async function updateDivision(newDivisionId: number | null) {
@@ -377,6 +380,8 @@ async function updateDivision(newDivisionId: number | null) {
 
   datasetStewardship.value.divisionId = newDivisionId
   clearBranch()
+
+  await saveAndNotify()
 }
 
 async function updateBranch(newBranchId: number | null) {
@@ -395,6 +400,8 @@ async function updateBranch(newBranchId: number | null) {
 
   datasetStewardship.value.branchId = newBranchId
   clearUnit()
+
+  await saveAndNotify()
 }
 
 async function updateUnit(newUnitId: number | null) {
@@ -412,9 +419,11 @@ async function updateUnit(newUnitId: number | null) {
   }
 
   datasetStewardship.value.unitId = newUnitId
+
+  await saveAndNotify()
 }
 
-async function saveWrapper() {
+async function saveAndNotify() {
   if (isNil(datasetStewardship.value)) {
     throw new Error("Dataset stewardship is not defined")
   }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/78

# Context

The owner region on the dataset description "manage" page has a save button and the other regions don't have saves (well they have the circle icon on the top).  From a user perspective I might think that the owner save button will save everything on the page.  I am not sure if it requires a different interaction or something.  But it would be nice if it could be consistent with the rest of the page.

# Implementation

Make the owner form card use auto-save like the rest of the page.

# Screenshots

New auto-save for "owner" section.
Note that this also shows off a new bug: https://github.com/icefoganalytics/internal-data-portal/issues/79
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/6607ad47-862b-45f6-b524-0d7327523fd6)

Old Pre-auto-save "owner" section"
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/671487e1-9fb9-4d0c-9085-68d9ee33dd52)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080 as a "Data Owner" or higher user type.
4. Click on the "Browse all data" button to go to the all datasets page http://localhost:8080/datasets?perPage=10&page=1.
5. Click on a dataset, or create a new one from the previous page.
6. Edit the dataset, via the "Edit" button in the top right corner.
7. Scroll down to the "Owner" section in the bottom left.
8. Note that the "save" button on the bottom right has been replace by a "save check" in the top right.
9. Note that now all "owner section" fields auto-save on update.
