### PR TITLE
BUG: Dataset Description Manage Owner Section Displaying Ids Instead Of Text

### DIFF
--- a/api/src/controllers/users-controller.ts
+++ b/api/src/controllers/users-controller.ts
@@ -1,5 +1,5 @@
-import { WhereOptions } from "sequelize"
-import { isNil } from "lodash"
+import { ModelStatic, WhereOptions } from "sequelize"
+import { isEmpty, isNil } from "lodash"
 
 import { User } from "@/models"
 import { UserSerializers } from "@/serializers"
@@ -11,9 +11,17 @@ import BaseController from "@/controllers/base-controller"
 export class UsersController extends BaseController {
   async index() {
     const where = this.query.where as WhereOptions<User>
+    const filters = this.query.filters as Record<string, unknown>
 
-    const totalCount = await User.count({ where })
-    const users = await User.findAll({
+    let filteredUsers: ModelStatic<User> = User
+    if (!isEmpty(filters)) {
+      Object.entries(filters).forEach(([key, value]) => {
+        filteredUsers = filteredUsers.scope({ method: [key, value] })
+      })
+    }
+
+    const totalCount = await filteredUsers.count({ where })
+    const users = await filteredUsers.findAll({
       where,
       limit: this.pagination.limit,
       offset: this.pagination.offset,

--- a/api/src/controllers/users-controller.ts
+++ b/api/src/controllers/users-controller.ts
@@ -39,7 +39,10 @@ export class UsersController extends BaseController {
   }
 
   async show() {
-    const user = await this.loadUser()
+    const withDeleted = this.query.withDeleted === "true"
+    const user = await this.loadUser({
+      withDeleted,
+    })
     if (isNil(user)) {
       return this.response.status(404).json({ message: "User not found." })
     }
@@ -127,8 +130,9 @@ export class UsersController extends BaseController {
     return User.build(this.request.body)
   }
 
-  private async loadUser() {
+  private async loadUser({ withDeleted = false }: { withDeleted?: boolean } = {}) {
     return User.findByPk(this.params.userId, {
+      paranoid: !withDeleted,
       include: [
         "roles",
         {

--- a/api/src/controllers/users/search-controller.ts
+++ b/api/src/controllers/users/search-controller.ts
@@ -36,13 +36,27 @@ export class SearchController extends BaseController {
       return {}
     }
 
+    const parts = searchToken.split(" ")
+    if (parts.length === 1) {
+      return {
+        [Op.or]: [
+          where(fn("LOWER", col("email")), { [Op.like]: `%${searchToken}%` }),
+          where(fn("LOWER", col("first_name")), { [Op.like]: `%${searchToken}%` }),
+          where(fn("LOWER", col("last_name")), { [Op.like]: `%${searchToken}%` }),
+          where(fn("LOWER", col("position")), { [Op.like]: `%${searchToken}%` }),
+        ],
+      }
+    }
+
     return {
-      [Op.or]: [
-        where(fn("LOWER", col("email")), { [Op.like]: `%${searchToken}%` }),
-        where(fn("LOWER", col("first_name")), { [Op.like]: `%${searchToken}%` }),
-        where(fn("LOWER", col("last_name")), { [Op.like]: `%${searchToken}%` }),
-        where(fn("LOWER", col("position")), { [Op.like]: `%${searchToken}%` }),
-      ],
+      [Op.and]: parts.map((part) => ({
+        [Op.or]: [
+          where(fn("LOWER", col("email")), { [Op.like]: `%${part}%` }),
+          where(fn("LOWER", col("first_name")), { [Op.like]: `%${part}%` }),
+          where(fn("LOWER", col("last_name")), { [Op.like]: `%${part}%` }),
+          where(fn("LOWER", col("position")), { [Op.like]: `%${part}%` }),
+        ],
+      })),
     }
   }
 }

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -275,7 +275,7 @@ User.init(
         const where = {
           [Op.or]: attributes.map((attribute) => ({
             [attribute]: {
-              [Op.not]: null,
+              [Op.and]: [{ [Op.not]: null }, { [Op.ne]: "" }],
             },
           })),
         }

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -18,6 +18,7 @@ import {
   InferAttributes,
   InferCreationAttributes,
   NonAttribute,
+  Op,
   col,
   fn,
   where,
@@ -264,6 +265,23 @@ User.init(
       byEmailIgnoreCase: (email: string) => {
         return {
           where: where(fn("LOWER", col("email")), email.toLowerCase()),
+        }
+      },
+      withPresenceOf(attributes: string[]) {
+        if (attributes.length === 0) {
+          throw new Error("Must provide at least one attribute to search for.")
+        }
+
+        const where = {
+          [Op.or]: attributes.map((attribute) => ({
+            [attribute]: {
+              [Op.not]: null,
+            },
+          })),
+        }
+
+        return {
+          where,
         }
       },
     },

--- a/web/src/api/users-api.ts
+++ b/web/src/api/users-api.ts
@@ -61,6 +61,11 @@ export type UserCreationAttributes = Partial<User> & {
   rolesAttributes?: Partial<Role>[]
 }
 
+// Keep in sync with api/src/models/user.ts -> scopes
+export type UsersFilters = {
+  withPresenceOf?: string[]
+}
+
 export const usersApi = {
   RoleTypes,
   // TODO: consider moving this to its own api?
@@ -71,6 +76,7 @@ export const usersApi = {
   async list(
     params: {
       where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
+      filters?: UsersFilters
       page?: number
       perPage?: number
     } = {}
@@ -108,16 +114,14 @@ export const usersApi = {
   // Special Endpoints
   async search(
     searchToken: string,
-    {
-      page,
-      perPage,
-    }: {
+    params: {
+      filters?: UsersFilters
       page?: number
       perPage?: number
     } = {}
   ): Promise<{ users: User[]; totalCount: number }> {
     const { data } = await http.get(`/api/users/search/${searchToken}`, {
-      params: { page, perPage },
+      params,
     })
     return data
   },

--- a/web/src/api/users-api.ts
+++ b/web/src/api/users-api.ts
@@ -64,6 +64,7 @@ export type UserCreationAttributes = Partial<User> & {
 // Keep in sync with api/src/models/user.ts -> scopes
 export type UsersFilters = {
   withPresenceOf?: string[]
+  withDeleted?: boolean
 }
 
 export const usersApi = {
@@ -87,8 +88,13 @@ export const usersApi = {
     const { data } = await http.get("/api/users", { params })
     return data
   },
-  async get(id: number): Promise<{ user: User }> {
-    const { data } = await http.get(`/api/users/${id}`)
+  async get(
+    id: number,
+    params: {
+      withDeleted?: boolean
+    } = {}
+  ): Promise<{ user: User }> {
+    const { data } = await http.get(`/api/users/${id}`, { params })
     return data
   },
   async create(attributes: UserCreationAttributes): Promise<{

--- a/web/src/components/datasets/OwnerFormCard.vue
+++ b/web/src/components/datasets/OwnerFormCard.vue
@@ -34,13 +34,7 @@
               auto-select-first
               required
               @update:model-value="updateOwner($event as unknown as number | null)"
-            >
-              <template #no-data>
-                <v-list-item>
-                  <v-btn block> TODO: Create New User </v-btn>
-                </v-list-item>
-              </template>
-            </UserSearchableAutocomplete>
+            />
           </v-col>
           <v-col
             cols="12"

--- a/web/src/components/datasets/OwnerFormCard.vue
+++ b/web/src/components/datasets/OwnerFormCard.vue
@@ -26,6 +26,7 @@
             <!-- TODO: enforce owner as current user if data_owner type -->
             <UserSearchableAutocomplete
               :model-value="datasetStewardship.ownerId"
+              :filters="{ withPresenceOf: ['firstName', 'lastName'] }"
               :rules="[required]"
               label="Owner Name *"
               item-value="id"
@@ -43,6 +44,7 @@
             <UserSearchableAutocomplete
               :model-value="datasetStewardship.ownerId"
               :disabled="datasetStewardship.ownerId === undefined"
+              :filters="{ withPresenceOf: ['position'] }"
               :rules="[required]"
               label="Owner Position *"
               item-value="id"
@@ -61,6 +63,7 @@
           >
             <UserSearchableAutocomplete
               :model-value="datasetStewardship.supportId"
+              :filters="{ withPresenceOf: ['firstName', 'lastName'] }"
               :rules="[required]"
               label="Support Name *"
               item-value="id"
@@ -97,6 +100,7 @@
             <UserSearchableAutocomplete
               :model-value="datasetStewardship.supportId"
               :disabled="datasetStewardship.supportId === undefined"
+              :filters="{ withPresenceOf: ['position'] }"
               :rules="[required]"
               label="Support Position *"
               item-value="id"

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -19,19 +19,13 @@
       </slot>
     </template>
     <template
-      v-for="slotName in dynamicSlots"
+      v-for="slotName in slotsNamesToPassThrough"
       #[slotName]="slotProps"
     >
       <slot
         :name="slotName"
         v-bind="slotProps"
       ></slot>
-    </template>
-    <template
-      v-for="slotName in staticSlots"
-      #[slotName]
-    >
-      <slot :name="slotName"></slot>
     </template>
   </v-autocomplete>
 </template>
@@ -42,20 +36,24 @@ import { debounce, isEmpty, isNil } from "lodash"
 
 import useUsers from "@/use/use-users"
 
-const dynamicSlots = [
-  "append",
+import { VAutocomplete } from "vuetify/lib/components/index.mjs"
+
+const slotsNamesToPassThrough: (keyof VAutocomplete["$slots"])[] = [
   "append-inner",
+  "append-item",
+  "append",
   "chip",
+  "clear",
   "details",
   "item",
   "label",
   "loader",
   "message",
-  "prepend",
+  "no-data",
   "prepend-inner",
+  "prepend",
   "selection",
-] as const
-const staticSlots = ["append-item", "clear", "no-data"] as const
+]
 
 const props = defineProps<{
   modelValue: number | null | undefined

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -34,41 +34,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, useSlots, watch } from "vue"
+import { ref, watch } from "vue"
 import { debounce, isEmpty, isNil } from "lodash"
 
 import useUsers from "@/use/use-users"
-
-// Slot passthrough with TypeScript
-import type { VAutocomplete } from "vuetify/lib/components/index.mjs"
-
-type WrappedSlotNames = keyof VAutocomplete["$slots"]
-const wrappedSlotNames = new Set<WrappedSlotNames>([
-  "append-inner",
-  "append-item",
-  "append",
-  "chip",
-  "clear",
-  "details",
-  "item",
-  "label",
-  "loader",
-  "message",
-  "no-data",
-  "prepend-inner",
-  "prepend-item",
-  "prepend",
-  "selection",
-])
-
-const slots = useSlots()
-
-const slotsNamesToPassThrough = computed(() => {
-  return Object.keys(slots).filter((slotName): slotName is WrappedSlotNames =>
-    wrappedSlotNames.has(slotName as WrappedSlotNames)
-  )
-})
-// End of slot passthrough with TypeScript
+import useVuetifySlotNamesPassThrough from "@/use/use-vuetify-slot-names-pass-through"
+import { VAutocomplete } from "vuetify/lib/components/index.mjs"
 
 const props = defineProps<{
   modelValue: number | null | undefined
@@ -123,4 +94,22 @@ const debouncedSearch = debounce((newSearchToken: string) => {
 function clearUsers() {
   users.value = []
 }
+
+const slotsNamesToPassThrough = useVuetifySlotNamesPassThrough<VAutocomplete>([
+  "append-inner",
+  "append-item",
+  "append",
+  "chip",
+  "clear",
+  "details",
+  "item",
+  "label",
+  "loader",
+  "message",
+  "no-data",
+  "prepend-inner",
+  "prepend-item",
+  "prepend",
+  "selection",
+])
 </script>

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -80,7 +80,7 @@ watch(
 )
 
 const { modelValue: userId } = toRefs(props)
-const { user } = useUser(userId)
+const { user } = useUser(userId, { withDeleted: true })
 const { users, isLoading, search } = useUsers(usersQuery, { isWatchEnabled: false })
 
 watch<[number | null | undefined, User | null, User[]], true>(

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -14,7 +14,24 @@
     @click:clear="clearUsers"
   >
     <template #prepend-item>
-      <v-list-item><em>Search for a user ...</em></v-list-item>
+      <slot name="prepend-item">
+        <v-list-item><em>Search for a user ...</em></v-list-item>
+      </slot>
+    </template>
+    <template
+      v-for="slotName in dynamicSlots"
+      #[slotName]="slotProps"
+    >
+      <slot
+        :name="slotName"
+        v-bind="slotProps"
+      ></slot>
+    </template>
+    <template
+      v-for="slotName in staticSlots"
+      #[slotName]
+    >
+      <slot :name="slotName"></slot>
     </template>
   </v-autocomplete>
 </template>
@@ -24,6 +41,21 @@ import { ref, watch } from "vue"
 import { debounce, isEmpty, isNil } from "lodash"
 
 import useUsers from "@/use/use-users"
+
+const dynamicSlots = [
+  "append",
+  "append-inner",
+  "chip",
+  "details",
+  "item",
+  "label",
+  "loader",
+  "message",
+  "prepend",
+  "prepend-inner",
+  "selection",
+] as const
+const staticSlots = ["append-item", "clear", "no-data"] as const
 
 const props = defineProps<{
   modelValue: number | null | undefined

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -103,9 +103,10 @@ function updateModelValue(value: number | undefined) {
 
 const searchWrapper = (newSearchToken: string) => {
   const searchAttribute: UserAttributes = props.itemTitle
-  const isStaleSearch = users.value.some(
-    (user) => user[searchAttribute] === newSearchToken || user.id === Number(newSearchToken)
-  )
+  const isStaleSearch =
+    users.value.some(
+      (user) => user[searchAttribute] === newSearchToken || user.id === parseInt(newSearchToken)
+    ) || props.modelValue === parseInt(newSearchToken)
   if (isStaleSearch) return
 
   searchToken.value = newSearchToken

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -38,7 +38,7 @@
 import { ref, watch } from "vue"
 import { assign, debounce, isEmpty, isNil } from "lodash"
 
-import useUsers, { type User } from "@/use/use-users"
+import useUsers, { type UsersFilters, type User } from "@/use/use-users"
 import useVuetifySlotNamesPassThrough from "@/use/use-vuetify-slot-names-pass-through"
 
 import { VAutocomplete } from "vuetify/lib/components/index.mjs"
@@ -48,10 +48,12 @@ type UserAttributes = keyof User
 const props = withDefaults(
   defineProps<{
     modelValue: number | null | undefined
-    itemTitle: UserAttributes
+    itemTitle?: UserAttributes
+    filters?: UsersFilters
   }>(),
   {
     itemTitle: "email",
+    filters: () => ({}),
   }
 )
 
@@ -62,10 +64,20 @@ const emit = defineEmits<{
 const searchToken = ref("")
 const usersQuery = ref<{
   where?: Record<string, unknown>
+  filters?: UsersFilters
   perPage: number
 }>({
   perPage: 5,
+  filters: props.filters,
 })
+
+watch(
+  () => props.filters,
+  (newValue) => {
+    assign(usersQuery.value, { filters: newValue })
+  }
+)
+
 const { users, isLoading, search, refresh } = useUsers(usersQuery, { isWatchEnabled: false })
 
 watch(

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -8,9 +8,11 @@ export { type User, type UserUpdate }
 export function useUser(
   id: Ref<number | null | undefined>,
   {
+    withDeleted = false,
     immediate = true,
   }: {
     immediate?: boolean
+    withDeleted?: boolean
   } = {}
 ) {
   const state = reactive<{
@@ -31,7 +33,7 @@ export function useUser(
 
     state.isLoading = true
     try {
-      const { user } = await usersApi.get(staticId)
+      const { user } = await usersApi.get(staticId, { withDeleted })
       state.user = user
       state.isErrored = false
       return user

--- a/web/src/use/use-users.ts
+++ b/web/src/use/use-users.ts
@@ -1,12 +1,13 @@
 import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
 
-import usersApi, { type User } from "@/api/users-api"
+import usersApi, { type UsersFilters, type User } from "@/api/users-api"
 
-export { type User }
+export { type User, type UsersFilters }
 
 export function useUsers(
   options: Ref<{
     where?: Record<string, unknown>
+    filters?: UsersFilters
     page?: number
     perPage?: number
   }> = ref({}),

--- a/web/src/use/use-vuetify-slot-names-pass-through.ts
+++ b/web/src/use/use-vuetify-slot-names-pass-through.ts
@@ -1,0 +1,26 @@
+import { ComputedRef, computed, useSlots } from "vue"
+
+type ComponentWithSlots = {
+  $slots: {
+    [key: string]: unknown
+  }
+}
+
+type SlotNamesExtractor<T> = T extends ComponentWithSlots ? keyof T["$slots"] & string : never
+
+export function useVuetifySlotNamesPassThrough<
+  Component extends ComponentWithSlots = never,
+  SlotNames extends SlotNamesExtractor<Component> = SlotNamesExtractor<Component>,
+>(slotsToPassThrough: SlotNames[]): ComputedRef<SlotNames[]> {
+  const wrappedSlotNames = new Set(slotsToPassThrough)
+
+  const slots = useSlots()
+
+  return computed(() => {
+    return Object.keys(slots).filter((slotName): slotName is SlotNames =>
+      wrappedSlotNames.has(slotName as SlotNames)
+    )
+  })
+}
+
+export default useVuetifySlotNamesPassThrough


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/79

# Context

**Describe the bug**
When "managing" the dataset description tab, the "owner" section shows ids for owner and support information when there are more than 10 users, and the id of the user isn't returned from the back-end.

This is also caused by the owner/support person referring to a delete user - a user with the deleted_at flag set.
The endpoint should probably have the ability to override this for read and edit mode.

**Expected behavior**
The user dropdowns should always include user information and not ids.

**Screenshots**

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/da89e77a-f782-47ce-a642-ce2f52275164)

**Additional context**

File in questions is `web/src/components/datasets/OwnerFormCard.vue`.
The various user lookup fields should be converted to back-end search and should _always_ include the currently selected user in the payload, or maybe load that user separately.

The `web/src/components/users/UserSearchableAutocomplete.vue` component will serve as a good starting point for solving this, though we might need a new component to handle the complexity.

# Implementation

Add the ability to filter user search auto-completes via presence of a specific attribute via a special scope.
Add ability to request returning deleted users.
Add ability to search on multiple work values.
Figure out a semi-safe, semi-generic slot pass-through pattern for Vuetify + TypeScript.

## Questions

Do I even need the search controller? I could probably replace it with an attribute specific scope.
e.g. /api/users?search[attribute] = search token

## Concerns

The search feature doesn't map well to the UI, as all "Owner" fields perform a full attribute search, instead of searching on their specific attribute. This could be fixed by adding a per-attribute search scope/filter.

# Screenshots

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/04f601e4-14ba-4654-97ee-9627ace597b1)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the all datasets page and pick a dataset that has a deleted user on it.
5. Go to the "edit" view of the dataset.
6. Check that the "owner" section of the dataset does not have any fields that display the user ID instead of the expected user property. 
7. Delete the owner of the dataset (set deletedAt: now()), and check that the fields still display user info after reload.
8. Use the search fields, and note that it will no longer show results that have empty values.
9. Check that exiting from an empty search does not result in the user ID showing up instead of the currently selected user info.
