### PR TITLE
Add Dataset Button to All Datasets Page

### DIFF
--- a/web/src/components/datasets/DatasetsTable.vue
+++ b/web/src/components/datasets/DatasetsTable.vue
@@ -27,6 +27,16 @@
             @click:clear="clearSearchQuery"
           />
         </v-col>
+        <v-col class="d-none d-md-flex justify-end align-center">
+          <v-btn
+            icon="mdi-cached"
+            color="primary"
+            variant="outlined"
+            size="x-small"
+            title="Refresh Datasets"
+            @click="refresh"
+          />
+        </v-col>
       </v-row>
     </template>
     <template #item.name="{ value, item: { slug } }">
@@ -200,8 +210,6 @@ function removeDisableRowHighlight(event: MouseEvent) {
     row.classList.remove("no-highlight")
   }
 }
-
-defineExpose({ refresh })
 </script>
 
 <style scoped>

--- a/web/src/pages/DatasetNewPage.vue
+++ b/web/src/pages/DatasetNewPage.vue
@@ -15,6 +15,10 @@ const { setBreadcrumbs } = useBreadcrumbs()
 
 setBreadcrumbs([
   {
+    title: "All Datasets",
+    to: { name: "DatasetsPage" },
+  },
+  {
     title: "Create Dataset",
     to: { name: "DatasetNewPage" },
   },

--- a/web/src/pages/DatasetsPage.vue
+++ b/web/src/pages/DatasetsPage.vue
@@ -25,7 +25,7 @@ const { setBreadcrumbs } = useBreadcrumbs()
 
 setBreadcrumbs([
   {
-    title: "All Dataset",
+    title: "All Datasets",
     to: { name: "DatasetsPage" },
   },
 ])

--- a/web/src/pages/DatasetsPage.vue
+++ b/web/src/pages/DatasetsPage.vue
@@ -1,32 +1,27 @@
 <template>
   <v-container>
-    <div class="d-flex justify-space-between align-baseline mb-3">
-      <h2 class="">All Dataset</h2>
+    <h2 class="d-flex flex-column flex-md-row justify-space-between">
+      All Dataset
 
       <v-btn
-        icon="mdi-cached"
+        class="mb-3"
         color="primary"
-        variant="outlined"
-        size="x-small"
-        title="Refresh Datasets"
-        @click="refresh"
-      />
-    </div>
+        :to="{ name: 'DatasetNewPage' }"
+      >
+        Add Dataset
+      </v-btn>
+    </h2>
 
-    <DatasetsTable ref="datasetsTable" />
+    <DatasetsTable />
   </v-container>
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue"
-
 import DatasetsTable from "@/components/datasets/DatasetsTable.vue"
 
 import { useBreadcrumbs } from "@/use/use-breadcrumbs"
 
 const { setBreadcrumbs } = useBreadcrumbs()
-
-const datasetsTable = ref<InstanceType<typeof DatasetsTable>>()
 
 setBreadcrumbs([
   {
@@ -34,8 +29,4 @@ setBreadcrumbs([
     to: { name: "DatasetsPage" },
   },
 ])
-
-function refresh() {
-  datasetsTable.value?.refresh()
-}
 </script>


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/72

# Context

Would be good to add the add data button to the all data grid to allow data owners to quickly create a dataset without having to navigate back to the dashboard.

# Implementation

Add button.
Update new dataset page breadcrumbs to point to all datasets page.

# Screenshots

Update Datasets Page
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/85b86e10-48b5-4a77-9eee-6f558681cbf5)

Updated Breadcrumbs
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/19ad2a36-0f1e-47cc-a01a-9587284e633b)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Click the "Browse all data" button in the Data Search panel.
5. Click the new "Add dataset" button to go to the new dataset form.
6. Click the new "all dataset" breadcrumb to go back to the all datasets page.
