### PR TITLE
BUG: Terms of Use Region Does Not Save on First Entry

### DIFF
--- a/api/src/controllers/datasets-controller.ts
+++ b/api/src/controllers/datasets-controller.ts
@@ -118,7 +118,8 @@ export class DatasetsController extends BaseController {
         permittedAttributes,
         this.currentUser
       )
-      return this.response.status(200).json({ dataset: updatedDataset })
+      const serializedDataset = ShowSerializer.perform(updatedDataset, this.currentUser)
+      return this.response.status(200).json({ dataset: serializedDataset })
     } catch (error) {
       return this.response.status(422).json({ message: `Dataset update failed: ${error}` })
     }

--- a/api/src/services/datasets/update-service.ts
+++ b/api/src/services/datasets/update-service.ts
@@ -19,7 +19,23 @@ export class UpdateService extends BaseService {
     // TODO: log user who performed update?
 
     return this.dataset.reload({
-      include: ["owner", "creator", "stewardship"],
+      include: [
+        {
+          association: "owner",
+          include: [
+            {
+              association: "groupMembership",
+              include: ["department", "division", "branch", "unit"],
+            },
+          ],
+        },
+        "creator",
+        "integration",
+        "stewardship",
+        "accessGrants",
+        "accessRequests",
+        "visualizationControl",
+      ],
     })
   }
 }

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -15,18 +15,16 @@
     @click:clear="clearUsers"
   >
     <template
+      v-if="!slotsNamesToPassThrough.includes('prepend-item')"
+      #prepend-item
+    >
+      <v-list-item><em>Search for a user ...</em></v-list-item>
+    </template>
+    <template
       v-for="slotName in slotsNamesToPassThrough"
       #[slotName]="slotProps"
     >
       <slot
-        v-if="slotName === 'prepend-item'"
-        :name="slotName"
-        v-bind="slotProps"
-      >
-        <v-list-item><em>Search for a user ...</em></v-list-item>
-      </slot>
-      <slot
-        v-else
         :name="slotName"
         v-bind="slotProps"
       ></slot>

--- a/web/src/components/users/UserSearchableAutocomplete.vue
+++ b/web/src/components/users/UserSearchableAutocomplete.vue
@@ -15,6 +15,20 @@
     @click:clear="clearUsers"
   >
     <template
+      v-if="!slotsNamesToPassThrough.includes('item')"
+      #item="{ props: itemProps }"
+    >
+      <v-list-item
+        v-if="isEmpty(itemProps.title)"
+        v-bind="itemProps"
+        subtitle="<empty>"
+      />
+      <v-list-item
+        v-else
+        v-bind="itemProps"
+      />
+    </template>
+    <template
       v-if="!slotsNamesToPassThrough.includes('prepend-item')"
       #prepend-item
     >


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/71

Relates to:

- https://github.com/icefoganalytics/internal-data-portal/pull/81

# Context

After the first create (register) of a dataset it takes the user to the manage screens to enter the rest of the information. I filled out all the the information top to bottom. Then navigated away as it looks to have an autosave when I navigated away the first region hadn't saved but the other regions (Subject, Owner notes) had. If I navigate back to the description tab and re-enter it seems to save fine.

## After Investigation

Every UI action after the first auto-save of the dataset "details" section would result in broken UI behaviour.

 I believe the source of the bug was a crash in the page JS due to the datasets API endpoint for update not returning an "integration" property on the dataset.
i.e.
```vue
// web/src/components/datasets/DataDescriptionFormCard.vue
{{ !isNil(dataset.integration.id) ? "Manage API Link" : "Add API Link" }}
```
was crashing all the JS, including the auto-save render logic. 

The saves appeared to propagate to the back-end, but the UI didn't update.

# Implementation

Fix bug by normalizing datasets controller show/update return format.
Update dataset create form to use new user search selector from https://github.com/icefoganalytics/internal-data-portal/pull/81

# Screenshots

Update datasets "new" page
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/2dca4076-d59f-4496-bfe3-d27e3d8b611e)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to the "all datasets page" by clicking the "browser all data" button.
5. Click the new "add dataset" button to go to the dataset creation page.
6. Note that the user pickers have been upgrade with search, and display empty fields correctly.
7. Create the dataset.
8. Update the description or terms of use, or credits fields.
9. Previous the page would silently crash after save, preventing secondary changes. Now it does not.
