### PR TITLE
Download CSV Name Dataset Name

### DIFF
--- a/api/src/controllers/dataset-entries-controller.ts
+++ b/api/src/controllers/dataset-entries-controller.ts
@@ -64,13 +64,14 @@ export class DatasetEntriesController extends BaseController {
       return genericFileName
     }
 
-    const dataset = await Dataset.findByPk(datasetId)
-    if (isNil(dataset)) {
+    const datasets = await Dataset.findAll({ where: { id: datasetId } })
+    const names = datasets.map((dataset) => dataset.name).join("-")
+
+    if (isEmpty(names)) {
       return genericFileName
     }
 
-    const { name } = dataset
-    return `Export, ${name}, ${date}.csv`
+    return `Export, ${names}, ${date}.csv`
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/86

# Context

**Is your feature request related to a problem? Please describe.**
When a user downloads a csv from the application the export is named something like "Export, Dataset Entries, 2024-03-29".  If the user downloaded a different dataset it would have a similiar name.  Potentially be confusing when they download a lot and go to use it.

**Describe the solution you'd like**
Can the download be renamed Dataset name - date or something more descriptive  eg. Buildings-2024-03-29.

# Implementation

Pull datasetId from query, and use it to load dataset, and fetch dataset name for CSV download.

# Screenshots

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/f8295cbe-aeb3-4751-a559-a5990bb83967)

![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/c80ce34a-ff3d-4c8a-8870-2ebb213c8a08)


# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Create a dataset with an integration.
5. Go to the dataset "visualize" tab, and download the dataset as a CSV.
6. Note that the file name now includes the dataset name.
