### PR TITLE
Search Box Populate With Dashboard Keyword

### DIFF
--- a/web/src/components/tags/TagsAutocomplete.vue
+++ b/web/src/components/tags/TagsAutocomplete.vue
@@ -49,7 +49,9 @@ const props = withDefaults(
   }
 )
 
-const emit = defineEmits(["update:modelValue"])
+const emit = defineEmits<{
+  "update:modelValue": [tagNames: string[]]
+}>()
 
 const selectedTagNames = ref<string[]>(props.modelValue)
 

--- a/web/src/use/use-datasets.ts
+++ b/web/src/use/use-datasets.ts
@@ -1,8 +1,8 @@
 import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
 
-import datasetsApi, { type Dataset } from "@/api/datasets-api"
+import datasetsApi, { type Dataset, type DatasetsFilters } from "@/api/datasets-api"
 
-export { type Dataset }
+export { type Dataset, type DatasetsFilters }
 
 export function useDatasets(
   options: Ref<{


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/85

# Context

**Is your feature request related to a problem? Please describe.**
When a user does a keyword search on the main dashboard it takes them to the data page with the data limited to the search.  In the search field it says click to clear or remove query. 
![image](https://github.com/icefoganalytics/internal-data-portal/assets/89539008/9c7ec962-e5e1-4a93-8f84-19f67943cdfb)


**Describe the solution you'd like**
I think it would be more user friendly to include the search in this field.  In the picture above it should show "buildings"

# Implementation

Implement a minimal search on the datasets page using the keyword search from the dashboard.

# Screenshots

New minimal search
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/f17d8eed-f97a-44f4-8d7b-b60897470736)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. From the dashboard, enter some keywords in the datasets search, then click search.
5. After the redirect to the datasets page, check that the search field is filled in with the keywords you selected previously.
6. Add/remove some search tags, and note that the page URL is updated.
