### PR TITLE
Part 1: Implement Improvements Developed in Meeting On 2024-03-27

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -17,6 +17,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-jwt": "^8.4.1",
+        "fast-csv": "^5.0.1",
         "helmet": "^7.1.0",
         "jmespath": "^0.16.0",
         "jwks-rsa": "^3.1.0",
@@ -1085,6 +1086,31 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/@fast-csv/format": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-5.0.0.tgz",
+      "integrity": "sha512-IyMpHwYIOGa2f0BJi6Wk55UF0oBA5urdIydoEDYxPo88LFbeb3Yr4rgpu98OAO1glUWheSnNtUgS80LE+/dqmw==",
+      "dependencies": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0"
+      }
+    },
+    "node_modules/@fast-csv/parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.0.tgz",
+      "integrity": "sha512-ecF8tCm3jVxeRjEB6VPzmA+1wGaJ5JgaUX2uesOXdXD6qQp0B3EdshOIed4yT1Xlj/F2f8v4zHSo0Oi31L697g==",
+      "dependencies": {
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isnil": "^4.0.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.uniq": "^4.5.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3933,6 +3959,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fast-csv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-5.0.1.tgz",
+      "integrity": "sha512-Q43zC4NdQD5MAWOVQOF8KA+D6ddvTJjX2ib8zqysm74jZhtk6+dc8C75/OqRV6Y9CLc4kgvbC3PLG8YL4YZfgw==",
+      "dependencies": {
+        "@fast-csv/format": "5.0.0",
+        "@fast-csv/parse": "5.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5859,6 +5897,16 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5869,10 +5917,25 @@
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng=="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
@@ -5888,6 +5951,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.isundefined": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
+      "integrity": "sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5911,6 +5979,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
     "node_modules/lru-cache": {
       "version": "4.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-jwt": "^8.4.1",
+    "fast-csv": "^5.0.1",
     "helmet": "^7.1.0",
     "jmespath": "^0.16.0",
     "jwks-rsa": "^3.1.0",

--- a/api/src/controllers/dataset-integrations-controller.ts
+++ b/api/src/controllers/dataset-integrations-controller.ts
@@ -57,13 +57,13 @@ export class DatasetIntegrationsController extends BaseController {
     }
 
     const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
-    const isPreview = this.query.isPreview === "true"
+    const skipDataProcessing = this.query.skipDataProcessing === "true"
     try {
       const updatedDatasetIntegration = await UpdateService.perform(
         datasetIntegration,
         permittedAttributes,
-        isPreview,
-        this.currentUser
+        this.currentUser,
+        { skipDataProcessing }
       )
       return this.response.status(200).json({ datasetIntegration: updatedDatasetIntegration })
     } catch (error) {

--- a/api/src/controllers/datasets/download-controller.ts
+++ b/api/src/controllers/datasets/download-controller.ts
@@ -27,8 +27,9 @@ export class DownloadController extends BaseController {
     try {
       await CreateService.perform(csvStream, dataset, this.currentUser, { searchToken })
     } catch (error) {
-      console.error("Failed to generate CSV", error)
-      this.response.status(500).send(`Failed to generate CSV: ${error}`)
+      console.error(`Failed to generate CSV: ${error}`)
+      csvStream.write(`Failed to generate CSV due to server error.\n`)
+      csvStream.write(`Error: ${error}\n`)
     } finally {
       csvStream.end()
     }

--- a/api/src/controllers/datasets/download-controller.ts
+++ b/api/src/controllers/datasets/download-controller.ts
@@ -1,0 +1,52 @@
+import { isEmpty, isNil } from "lodash"
+import { WhereOptions } from "sequelize"
+import { createReadStream } from "fs"
+
+import { Dataset, DatasetEntry } from "@/models"
+import { DatasetEntries } from "@/services"
+
+import { BaseController } from "@/controllers/base-controller"
+import { DatasetEntriesPolicy } from "@/policies"
+
+export class DownloadController extends BaseController {
+  async create() {
+    try {
+      const dataset = await this.loadDataset()
+      if (isNil(dataset)) {
+        return this.response.status(404).send("Dataset not found.")
+      }
+
+      const fileName = await this.buildFileName(dataset.name)
+      this.response.header("Content-Type", "text/csv")
+      this.response.attachment(fileName)
+
+      const where = this.query.where as WhereOptions<DatasetEntry>
+      const searchToken = this.query.searchToken as string
+      const scopedDatasetEntries = DatasetEntriesPolicy.applyScope(DatasetEntry, this.currentUser)
+      let filteredDatasetEntries = scopedDatasetEntries
+      if (!isEmpty(searchToken)) {
+        filteredDatasetEntries = scopedDatasetEntries.scope({ method: ["search", searchToken] })
+      }
+
+      const filePath = await DatasetEntries.CreateCsvService.perform(filteredDatasetEntries, where)
+
+      const fileStream = createReadStream(filePath)
+      fileStream.pipe(this.response)
+    } catch (error) {
+      console.error("Failed to generate CSV", error)
+      this.response.status(500).send(`Failed to generate CSV: ${error}`)
+    }
+  }
+
+  private async loadDataset(): Promise<Dataset | null> {
+    const { datasetIdOrSlug } = this.request.params
+    return Dataset.findBySlugOrPk(datasetIdOrSlug)
+  }
+
+  private async buildFileName(datasetName: string) {
+    const date = new Date().toISOString().split("T")[0]
+    return `Export, ${datasetName}, ${date}.csv`
+  }
+}
+
+export default DownloadController

--- a/api/src/controllers/datasets/index.ts
+++ b/api/src/controllers/datasets/index.ts
@@ -1,1 +1,2 @@
+export { DownloadController } from "./download-controller"
 export { EmailSubscribersController } from "./email-subscribers-controller"

--- a/api/src/db/migrations/2024.04.03T23.02.01.add-metadata-fields-to-dataset-integrations-table.ts
+++ b/api/src/db/migrations/2024.04.03T23.02.01.add-metadata-fields-to-dataset-integrations-table.ts
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize"
+
+import type { Migration } from "@/db/umzug"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("dataset_integrations", "estimated_size_in_bytes", {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  })
+
+  await queryInterface.addColumn("dataset_integrations", "estimated_number_of_records", {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  })
+
+  await queryInterface.addColumn("dataset_integrations", "estimated_response_time_in_ms", {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("dataset_integrations", "estimated_size_in_bytes")
+  await queryInterface.removeColumn("dataset_integrations", "estimated_number_of_records")
+  await queryInterface.removeColumn("dataset_integrations", "estimated_response_time_in_ms")
+}

--- a/api/src/middlewares/body-authorization-hoist-middleware.ts
+++ b/api/src/middlewares/body-authorization-hoist-middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from "express"
+
+export function bodyAuthorizationHoistMiddleware(req: Request, res: Response, next: NextFunction) {
+  const accessToken = req.body.IDP_AUTHORIZATION_TOKEN
+  if (accessToken && !req.headers.authorization) {
+    req.headers.authorization = `Bearer ${accessToken}`
+    delete req.body.IDP_AUTHORIZATION_TOKEN
+  }
+
+  next()
+}
+
+export default bodyAuthorizationHoistMiddleware

--- a/api/src/models/dataset-integration.ts
+++ b/api/src/models/dataset-integration.ts
@@ -72,20 +72,16 @@ export class DatasetIntegration extends Model<
     this.belongsTo(Dataset, { as: "dataset" })
   }
 
-  async activate(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
+  async activate(
+    this: DatasetIntegration
+  ): Promise<NonAttribute<DatasetIntegrationRawJsonDataType>> {
     return activate(this)
   }
 
-  isRefreshRequired(): NonAttribute<boolean> {
-    return this.changed("url") || this.changed("headerKey") || this.changed("headerValue")
-  }
-
-  async refreshIfRequired(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
-    if (this.isRefreshRequired()) {
-      return this.activate()
-    }
-
-    return this
+  async refresh(
+    this: DatasetIntegration
+  ): Promise<NonAttribute<DatasetIntegrationRawJsonDataType>> {
+    return this.activate()
   }
 }
 

--- a/api/src/models/dataset-integration.ts
+++ b/api/src/models/dataset-integration.ts
@@ -15,15 +15,19 @@ import {
 import sequelize from "@/db/db-client"
 
 import Dataset from "@/models/dataset"
+import { activate } from "@/models/dataset-integrations"
 
 // Keep in sync with web/src/api/dataset-fields-api.ts
 export enum DatasetIntegrationStatusTypes {
   OK = "ok",
   ERRORED = "errored",
+  PENDING = "pending",
 }
 
 export type DatasetIntegrationRawJsonDataType = Record<string, unknown>
 export type DatasetIntegrationParsedJsonDataType = Record<string, unknown>[]
+
+export const MAX_RECORDS = 100 // TODO: consider making this configurable?
 
 export class DatasetIntegration extends Model<
   InferAttributes<DatasetIntegration>,
@@ -66,6 +70,14 @@ export class DatasetIntegration extends Model<
 
   static establishAssociations() {
     this.belongsTo(Dataset, { as: "dataset" })
+  }
+
+  async activate(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
+    return activate(this)
+  }
+
+  async refresh(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
+    return this.activate()
   }
 }
 

--- a/api/src/models/dataset-integration.ts
+++ b/api/src/models/dataset-integration.ts
@@ -42,6 +42,9 @@ export class DatasetIntegration extends Model<
   declare status: DatasetIntegrationStatusTypes
   declare errorCode: CreationOptional<string | null>
   declare errorDetails: CreationOptional<string | null>
+  declare estimatedSizeInBytes: CreationOptional<number | null>
+  declare estimatedNumberOfRecords: CreationOptional<number | null>
+  declare estimatedResponseTimeInMs: CreationOptional<number | null>
   declare lastSuccessAt: CreationOptional<Date | null>
   declare lastFailureAt: CreationOptional<Date | null>
   declare createdAt: CreationOptional<Date>
@@ -136,6 +139,18 @@ DatasetIntegration.init(
     },
     errorDetails: {
       type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    estimatedSizeInBytes: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    estimatedNumberOfRecords: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    estimatedResponseTimeInMs: {
+      type: DataTypes.INTEGER,
       allowNull: true,
     },
     lastSuccessAt: {

--- a/api/src/models/dataset-integration.ts
+++ b/api/src/models/dataset-integration.ts
@@ -76,8 +76,16 @@ export class DatasetIntegration extends Model<
     return activate(this)
   }
 
+  isRefreshRequired(): NonAttribute<boolean> {
+    return this.changed("url") || this.changed("headerKey") || this.changed("headerValue")
+  }
+
   async refresh(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
-    return this.activate()
+    if (this.isRefreshRequired()) {
+      return this.activate()
+    }
+
+    return this
   }
 }
 

--- a/api/src/models/dataset-integration.ts
+++ b/api/src/models/dataset-integration.ts
@@ -80,7 +80,7 @@ export class DatasetIntegration extends Model<
     return this.changed("url") || this.changed("headerKey") || this.changed("headerValue")
   }
 
-  async refresh(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
+  async refreshIfRequired(this: DatasetIntegration): Promise<NonAttribute<DatasetIntegration>> {
     if (this.isRefreshRequired()) {
       return this.activate()
     }

--- a/api/src/models/dataset-integrations/activate.ts
+++ b/api/src/models/dataset-integrations/activate.ts
@@ -1,0 +1,106 @@
+import axios from "axios"
+import { isNil } from "lodash"
+
+import truncateDeep from "@/utils/truncate-deep"
+import countDeep from "@/utils/count-deep"
+
+import DatasetIntegration, {
+  DatasetIntegrationStatusTypes,
+  type DatasetIntegrationRawJsonDataType,
+  MAX_RECORDS,
+} from "@/models/dataset-integration"
+
+export async function activate(
+  datasetIntegration: DatasetIntegration
+): Promise<DatasetIntegration> {
+  const { url, headerKey, headerValue } = datasetIntegration
+
+  if (isNil(url)) {
+    throw new Error("url is required")
+  }
+
+  let headers = {}
+  if (!isNil(headerKey)) {
+    headers = {
+      [headerKey]: headerValue,
+    }
+  }
+
+  let {
+    rawJsonData,
+    estimatedResponseTimeInMs,
+    estimatedSizeInBytes,
+    estimatedNumberOfRecords,
+    status,
+    lastSuccessAt,
+  } = datasetIntegration
+  try {
+    ;({ rawJsonData, estimatedResponseTimeInMs, estimatedSizeInBytes, estimatedNumberOfRecords } =
+      await fetchRawIntegrationData(url, headers))
+    status = DatasetIntegrationStatusTypes.OK
+    lastSuccessAt = new Date()
+  } catch (error) {
+    throw new Error(`Failed to establish integration with ${url}: ${error}`)
+  }
+
+  return datasetIntegration.set({
+    status,
+    rawJsonData,
+    estimatedResponseTimeInMs,
+    estimatedSizeInBytes,
+    estimatedNumberOfRecords,
+    lastSuccessAt,
+  })
+}
+
+async function fetchRawIntegrationData(
+  url: string,
+  headers?: Record<string, string>
+): Promise<{
+  rawJsonData: DatasetIntegrationRawJsonDataType
+  estimatedResponseTimeInMs: number
+  estimatedSizeInBytes: number
+  estimatedNumberOfRecords: number
+}> {
+  const startTimeMs = new Date().getTime()
+  const { data, headers: responseHeaders } = await axios.get(url, {
+    headers,
+  })
+  const endTimeMs = new Date().getTime()
+  const estimatedResponseTimeInMs = endTimeMs - startTimeMs
+
+  const estimatedSizeInBytes = estimateSizeInBytes(data, responseHeaders["content-length"])
+  const estimatedNumberOfRecords = estimateNumberOfRecords(data)
+
+  const truncatedData = truncateDeep(data, MAX_RECORDS)
+
+  return {
+    rawJsonData: truncatedData,
+    estimatedResponseTimeInMs,
+    estimatedSizeInBytes,
+    estimatedNumberOfRecords,
+  }
+}
+
+function estimateSizeInBytes(data: object, contentLength?: string): number {
+  if (contentLength) {
+    return parseInt(contentLength, 10)
+  }
+
+  return new TextEncoder().encode(JSON.stringify(data)).length
+}
+
+function estimateNumberOfRecords(data: object): number {
+  if (
+    typeof data === "object" &&
+    !isNil(data) &&
+    "count" in data &&
+    typeof data.count === "number"
+  ) {
+    return data.count
+  }
+
+  return countDeep(data)
+}
+
+export default activate

--- a/api/src/models/dataset-integrations/index.ts
+++ b/api/src/models/dataset-integrations/index.ts
@@ -1,0 +1,1 @@
+export { activate } from "./activate"

--- a/api/src/policies/datasets-policy.ts
+++ b/api/src/policies/datasets-policy.ts
@@ -52,6 +52,24 @@ export class DatasetsPolicy extends BasePolicy<Dataset> {
     return false
   }
 
+  // TODO: condider refactoring; effectively the same as VisualizationControlsPolicy#show
+  // Maybe this should be shared logic?
+  download(): boolean {
+    if (this.update()) {
+      return true
+    }
+
+    if (this.record.isAccessibleViaOpenAccessGrantBy(this.user)) {
+      return true
+    }
+
+    if (this.record.hasApprovedAccessRequestFor(this.user)) {
+      return true
+    }
+
+    return false
+  }
+
   static applyScope(modelClass: ModelStatic<Dataset>, user: User): ModelStatic<Dataset> {
     if (user.isSystemAdmin || user.isBusinessAnalyst) {
       return modelClass

--- a/api/src/services/dataset-integrations/create-service.ts
+++ b/api/src/services/dataset-integrations/create-service.ts
@@ -1,6 +1,9 @@
 import { isNil } from "lodash"
 import axios from "axios"
 
+import countDeep from "@/utils/count-deep"
+import truncateDeep from "@/utils/truncate-deep"
+
 import { DatasetIntegration, User } from "@/models"
 import {
   DatasetIntegrationRawJsonDataType,
@@ -10,6 +13,8 @@ import {
 import BaseService from "@/services/base-service"
 
 type Attributes = Partial<DatasetIntegration>
+
+const MAX_RECORDS = 100 // TODO: consider making this configurable?
 
 export class CreateService extends BaseService {
   constructor(
@@ -39,9 +44,13 @@ export class CreateService extends BaseService {
 
     let status: DatasetIntegrationStatusTypes
     let rawJsonData: DatasetIntegrationRawJsonDataType | null = null
+    let estimatedResponseTimeInMs: number | null = null
+    let estimatedSizeInBytes: number | null = null
+    let estimatedNumberOfRecords: number | null = null
     let lastSuccessAt: Date | null = null
     try {
-      rawJsonData = await this.fetchRawIntegrationData(url, headers)
+      ;({ rawJsonData, estimatedResponseTimeInMs, estimatedSizeInBytes, estimatedNumberOfRecords } =
+        await this.fetchRawIntegrationData(url, headers))
       status = DatasetIntegrationStatusTypes.OK
       lastSuccessAt = new Date()
     } catch (error) {
@@ -54,6 +63,9 @@ export class CreateService extends BaseService {
       ...optionalAttributes,
       status,
       rawJsonData,
+      estimatedResponseTimeInMs,
+      estimatedSizeInBytes,
+      estimatedNumberOfRecords,
       lastSuccessAt,
     })
 
@@ -65,12 +77,51 @@ export class CreateService extends BaseService {
   private async fetchRawIntegrationData(
     url: string,
     headers?: Record<string, string>
-  ): Promise<DatasetIntegrationRawJsonDataType> {
-    const { data } = await axios.get(url, {
+  ): Promise<{
+    rawJsonData: DatasetIntegrationRawJsonDataType
+    estimatedResponseTimeInMs: number
+    estimatedSizeInBytes: number
+    estimatedNumberOfRecords: number
+  }> {
+    const startTimeMs = new Date().getTime()
+    const { data, headers: responseHeaders } = await axios.get(url, {
       headers,
     })
+    const endTimeMs = new Date().getTime()
+    const estimatedResponseTimeInMs = endTimeMs - startTimeMs
 
-    return data
+    const estimatedSizeInBytes = this.estimateSizeInBytes(data, responseHeaders["content-length"])
+    const estimatedNumberOfRecords = this.estimateNumberOfRecords(data)
+
+    const truncatedData = truncateDeep(data, MAX_RECORDS)
+
+    return {
+      rawJsonData: truncatedData,
+      estimatedResponseTimeInMs,
+      estimatedSizeInBytes,
+      estimatedNumberOfRecords,
+    }
+  }
+
+  private estimateSizeInBytes(data: object, contentLength?: string): number {
+    if (contentLength) {
+      return parseInt(contentLength, 10)
+    }
+
+    return new TextEncoder().encode(JSON.stringify(data)).length
+  }
+
+  private estimateNumberOfRecords(data: object): number {
+    if (
+      typeof data === "object" &&
+      !isNil(data) &&
+      "count" in data &&
+      typeof data.count === "number"
+    ) {
+      return data.count
+    }
+
+    return countDeep(data)
   }
 }
 

--- a/api/src/services/dataset-integrations/create-service.ts
+++ b/api/src/services/dataset-integrations/create-service.ts
@@ -1,20 +1,11 @@
 import { isNil } from "lodash"
-import axios from "axios"
-
-import countDeep from "@/utils/count-deep"
-import truncateDeep from "@/utils/truncate-deep"
 
 import { DatasetIntegration, User } from "@/models"
-import {
-  DatasetIntegrationRawJsonDataType,
-  DatasetIntegrationStatusTypes,
-} from "@/models/dataset-integration"
+import { DatasetIntegrationStatusTypes } from "@/models/dataset-integration"
 
 import BaseService from "@/services/base-service"
 
 type Attributes = Partial<DatasetIntegration>
-
-const MAX_RECORDS = 100 // TODO: consider making this configurable?
 
 export class CreateService extends BaseService {
   constructor(
@@ -35,93 +26,17 @@ export class CreateService extends BaseService {
       throw new Error("url is required")
     }
 
-    let headers = {}
-    if (!isNil(optionalAttributes.headerKey)) {
-      headers = {
-        [optionalAttributes.headerKey]: optionalAttributes.headerValue,
-      }
-    }
-
-    let status: DatasetIntegrationStatusTypes
-    let rawJsonData: DatasetIntegrationRawJsonDataType | null = null
-    let estimatedResponseTimeInMs: number | null = null
-    let estimatedSizeInBytes: number | null = null
-    let estimatedNumberOfRecords: number | null = null
-    let lastSuccessAt: Date | null = null
-    try {
-      ;({ rawJsonData, estimatedResponseTimeInMs, estimatedSizeInBytes, estimatedNumberOfRecords } =
-        await this.fetchRawIntegrationData(url, headers))
-      status = DatasetIntegrationStatusTypes.OK
-      lastSuccessAt = new Date()
-    } catch (error) {
-      throw new Error(`Failed to establish integration with ${url}: ${error}`)
-    }
-
-    const datasetIntegration = await DatasetIntegration.create({
+    const datasetIntegration = DatasetIntegration.build({
       datasetId,
       url,
+      status: DatasetIntegrationStatusTypes.PENDING,
       ...optionalAttributes,
-      status,
-      rawJsonData,
-      estimatedResponseTimeInMs,
-      estimatedSizeInBytes,
-      estimatedNumberOfRecords,
-      lastSuccessAt,
     })
+    await datasetIntegration.activate()
 
     // TODO: log creating user
 
-    return datasetIntegration
-  }
-
-  private async fetchRawIntegrationData(
-    url: string,
-    headers?: Record<string, string>
-  ): Promise<{
-    rawJsonData: DatasetIntegrationRawJsonDataType
-    estimatedResponseTimeInMs: number
-    estimatedSizeInBytes: number
-    estimatedNumberOfRecords: number
-  }> {
-    const startTimeMs = new Date().getTime()
-    const { data, headers: responseHeaders } = await axios.get(url, {
-      headers,
-    })
-    const endTimeMs = new Date().getTime()
-    const estimatedResponseTimeInMs = endTimeMs - startTimeMs
-
-    const estimatedSizeInBytes = this.estimateSizeInBytes(data, responseHeaders["content-length"])
-    const estimatedNumberOfRecords = this.estimateNumberOfRecords(data)
-
-    const truncatedData = truncateDeep(data, MAX_RECORDS)
-
-    return {
-      rawJsonData: truncatedData,
-      estimatedResponseTimeInMs,
-      estimatedSizeInBytes,
-      estimatedNumberOfRecords,
-    }
-  }
-
-  private estimateSizeInBytes(data: object, contentLength?: string): number {
-    if (contentLength) {
-      return parseInt(contentLength, 10)
-    }
-
-    return new TextEncoder().encode(JSON.stringify(data)).length
-  }
-
-  private estimateNumberOfRecords(data: object): number {
-    if (
-      typeof data === "object" &&
-      !isNil(data) &&
-      "count" in data &&
-      typeof data.count === "number"
-    ) {
-      return data.count
-    }
-
-    return countDeep(data)
+    return datasetIntegration.save()
   }
 }
 

--- a/api/src/services/dataset-integrations/update-service.ts
+++ b/api/src/services/dataset-integrations/update-service.ts
@@ -22,7 +22,7 @@ export class UpdateService extends BaseService {
   async perform(): Promise<DatasetIntegration> {
     return db.transaction(async () => {
       this.datasetIntegration.set(this.attributes)
-      await this.datasetIntegration.refresh()
+      await this.datasetIntegration.refreshIfRequired()
 
       if (this.controlFlags.skipDataProcessing) {
         return this.datasetIntegration.save()

--- a/api/src/services/dataset-integrations/update-service.ts
+++ b/api/src/services/dataset-integrations/update-service.ts
@@ -34,7 +34,7 @@ export class UpdateService extends BaseService {
 
       // TODO: log user action
 
-      return this.datasetIntegration
+      return this.datasetIntegration.save()
     })
   }
 
@@ -46,7 +46,7 @@ export class UpdateService extends BaseService {
     }
 
     if (isNil(jmesPathTransform) && isArray(rawJsonData)) {
-      return datasetIntegration.update({
+      return datasetIntegration.set({
         parsedJsonData: rawJsonData,
       })
     }
@@ -56,7 +56,7 @@ export class UpdateService extends BaseService {
     }
 
     const parsedJsonData = jmespath.search(rawJsonData, jmesPathTransform)
-    return datasetIntegration.update({
+    return datasetIntegration.set({
       parsedJsonData,
     })
   }

--- a/api/src/services/dataset-integrations/update-service.ts
+++ b/api/src/services/dataset-integrations/update-service.ts
@@ -27,6 +27,8 @@ export class UpdateService extends BaseService {
   async perform(): Promise<DatasetIntegration> {
     const { url, headerKey, headerValue } = this.attributes
 
+    // TODO: consider recreating dataset as this is more of an upsert at this point?
+    // START: data refresh
     let status: DatasetIntegrationStatusTypes = this.datasetIntegration.status
     let rawJsonData: DatasetIntegrationRawJsonDataType | null = this.datasetIntegration.rawJsonData
     let lastSuccessAt: Date | null = this.datasetIntegration.lastSuccessAt
@@ -53,6 +55,7 @@ export class UpdateService extends BaseService {
         throw new Error(`Failed to establish integration with ${url}: ${error}`)
       }
     }
+    // END: data refresh
 
     return db.transaction(async () => {
       await this.datasetIntegration.update({

--- a/api/src/services/dataset-integrations/update-service.ts
+++ b/api/src/services/dataset-integrations/update-service.ts
@@ -22,7 +22,14 @@ export class UpdateService extends BaseService {
   async perform(): Promise<DatasetIntegration> {
     return db.transaction(async () => {
       this.datasetIntegration.set(this.attributes)
-      await this.datasetIntegration.refreshIfRequired()
+
+      if (
+        this.datasetIntegration.changed("url") ||
+        this.datasetIntegration.changed("headerKey") ||
+        this.datasetIntegration.changed("headerValue")
+      ) {
+        await this.datasetIntegration.refresh()
+      }
 
       if (this.controlFlags.skipDataProcessing) {
         return this.datasetIntegration.save()

--- a/api/src/services/datasets/download/create-service.ts
+++ b/api/src/services/datasets/download/create-service.ts
@@ -1,0 +1,93 @@
+import { CsvFormatterStream } from "fast-csv"
+import { isArray, isEmpty, isNil, isUndefined } from "lodash"
+import jmespath from "jmespath"
+
+import { Dataset, DatasetIntegration, User } from "@/models"
+import {
+  DatasetIntegrationParsedJsonDataType,
+  DatasetIntegrationRawJsonDataType,
+} from "@/models/dataset-integration"
+
+import BaseService from "@/services/base-service"
+
+export class CreateService extends BaseService {
+  constructor(
+    private csvStream: CsvFormatterStream<string[], string[]>,
+    private dataset: Dataset,
+    private currentUser: User,
+    private options: {
+      searchToken?: string
+    }
+  ) {
+    super()
+  }
+
+  async perform(): Promise<void> {
+    const { integration, fields } = this.dataset
+
+    if (isNil(integration)) {
+      throw new Error("Dataset is missing an integration assocation")
+    }
+
+    if (isUndefined(fields)) {
+      throw new Error("Dataset is missing fields association")
+    }
+
+    const headers = fields.map((field) => field.displayName)
+    const headerKeys = fields.map((field) => field.name)
+    this.csvStream.write(headers)
+
+    const allRawJsonData = await integration.refresh()
+    await integration.save()
+    const parsedJsonData = this.parseJsonData(integration, allRawJsonData)
+
+    const searchToken = this.options.searchToken
+
+    parsedJsonData.forEach((entry) => {
+      const dataFromFields = headerKeys.map((field) => entry[field])
+
+      let dataFromSearch = dataFromFields
+      if (!isNil(searchToken) && !isEmpty(searchToken)) {
+        dataFromSearch = dataFromFields.filter((value) => this.matchesSearch(value, searchToken))
+      }
+
+      this.csvStream.write(dataFromSearch)
+    })
+
+    return
+  }
+
+  /**
+   * Should match logic in api/src/models/dataset-entries/dataset-entries-search.ts
+   */
+  private matchesSearch(value: unknown, searchToken: string) {
+    switch (typeof value) {
+      case "string":
+        return value.toLowerCase().includes(searchToken.toLowerCase())
+      case "number":
+        return value.toString() === searchToken.toLowerCase()
+      default:
+        return false
+    }
+  }
+
+  private parseJsonData(
+    datasetIntegration: DatasetIntegration,
+    allRawJsonData: DatasetIntegrationRawJsonDataType
+  ): DatasetIntegrationParsedJsonDataType {
+    const { jmesPathTransform } = datasetIntegration
+
+    if (isNil(jmesPathTransform) && isArray(allRawJsonData)) {
+      return allRawJsonData
+    }
+
+    if (isNil(jmesPathTransform)) {
+      throw new Error("An integration must parse to an array to be valid")
+    }
+
+    const parsedJsonData = jmespath.search(allRawJsonData, jmesPathTransform)
+    return parsedJsonData
+  }
+}
+
+export default CreateService

--- a/api/src/services/datasets/download/index.ts
+++ b/api/src/services/datasets/download/index.ts
@@ -1,0 +1,1 @@
+export { CreateService } from "./create-service"

--- a/api/src/services/datasets/index.ts
+++ b/api/src/services/datasets/index.ts
@@ -1,2 +1,4 @@
 export { CreateService } from "./create-service"
 export { UpdateService } from "./update-service"
+
+export * as Download from "./download"

--- a/api/src/utils/count-deep.ts
+++ b/api/src/utils/count-deep.ts
@@ -1,0 +1,18 @@
+import { forEach, isArray, isObject } from "lodash"
+
+export function countDeep<T extends object>(object: T): number {
+  let count = 0
+
+  function countArrays(value: T | T[keyof T]) {
+    if (isArray(value)) {
+      count += value.length
+    } else if (isObject(value)) {
+      forEach(value, countArrays)
+    }
+  }
+
+  countArrays(object)
+  return count
+}
+
+export default countDeep

--- a/api/src/utils/truncate-deep.ts
+++ b/api/src/utils/truncate-deep.ts
@@ -1,0 +1,17 @@
+import { isArray, isObject, mapValues, take } from "lodash"
+
+export function truncateDeep<T extends object>(object: T, maxRecords: number): T {
+  function truncate(value: T): unknown {
+    if (isArray(value)) {
+      return take(value, maxRecords)
+    } else if (isObject(value)) {
+      return mapValues(value, truncate)
+    }
+
+    return value
+  }
+
+  return truncate(object) as T
+}
+
+export default truncateDeep

--- a/web/src/api/dataset-integrations-api.ts
+++ b/web/src/api/dataset-integrations-api.ts
@@ -45,7 +45,7 @@ export const datasetIntegrationsApi = {
   async update(
     datasetIntegrationId: number,
     attributes: Partial<DatasetIntegration>,
-    controlFlags: { isPreview?: boolean } = {}
+    controlFlags: { skipDataProcessing?: boolean } = {}
   ): Promise<{
     datasetIntegration: DatasetIntegration
   }> {

--- a/web/src/components/dataset-entries/DatasetEntriesTable.vue
+++ b/web/src/components/dataset-entries/DatasetEntriesTable.vue
@@ -29,7 +29,9 @@
           <DownloadAsCsvButton
             v-if="visualizationControl?.isDownloadableAsCsv"
             :dataset-id="datasetId"
-            :query="datasetEntriesQuery"
+            :query="{
+              searchToken,
+            }"
           />
         </v-col>
       </v-row>

--- a/web/src/components/dataset-entries/DatasetEntriesTable.vue
+++ b/web/src/components/dataset-entries/DatasetEntriesTable.vue
@@ -28,6 +28,7 @@
         <v-col class="d-flex justify-end align-center">
           <DownloadAsCsvButton
             v-if="visualizationControl?.isDownloadableAsCsv"
+            :dataset-id="datasetId"
             :query="datasetEntriesQuery"
           />
         </v-col>

--- a/web/src/components/dataset-fields/DatasetFieldCreateDialog.vue
+++ b/web/src/components/dataset-fields/DatasetFieldCreateDialog.vue
@@ -117,6 +117,7 @@ const snack = useSnack()
 const datasetFieldTypes = Object.values(DatasetFieldDataTypes)
 const datasetField = ref<Partial<DatasetField>>({
   datasetId: props.datasetId,
+  dataType: DatasetFieldDataTypes.TEXT,
 })
 
 const router = useRouter()
@@ -177,6 +178,7 @@ async function createAndClose() {
 function resetDatasetField() {
   datasetField.value = {
     datasetId: props.datasetId,
+    dataType: DatasetFieldDataTypes.TEXT,
   }
 }
 </script>

--- a/web/src/components/dataset-integrations/DatasetIntegrationUpdateForm.vue
+++ b/web/src/components/dataset-integrations/DatasetIntegrationUpdateForm.vue
@@ -35,7 +35,7 @@
           :loading="isLoading"
           variant="outlined"
           color="primary"
-          @click="updateDatasetIntegration({ isPreview: true })"
+          @click="updateDatasetIntegration({ skipDataProcessing: true })"
         >
           Update Preview
         </v-btn>
@@ -225,7 +225,9 @@ function updateAndCompleteIntegration() {
   emit("completed")
 }
 
-async function updateDatasetIntegration({ isPreview = false }: { isPreview?: boolean } = {}) {
+async function updateDatasetIntegration({
+  skipDataProcessing = false,
+}: { skipDataProcessing?: boolean } = {}) {
   if (!isValid.value) {
     snack.notify("Please fill out all required fields", {
       color: "error",
@@ -252,7 +254,7 @@ async function updateDatasetIntegration({ isPreview = false }: { isPreview?: boo
     const { datasetIntegration: newDatasetIntegration } = await datasetIntegrationsApi.update(
       datasetIntegrationId,
       attributes,
-      { isPreview }
+      { skipDataProcessing }
     )
     datasetIntegration.value = newDatasetIntegration
     snack.notify("Dataset integration saved!", {

--- a/web/src/components/datasets/DataDescriptionFormCard.vue
+++ b/web/src/components/datasets/DataDescriptionFormCard.vue
@@ -44,13 +44,24 @@
                 class="d-flex justify-center mt-3"
               >
                 <v-btn
+                  v-if="isNil(dataset.integration.id)"
                   color="primary"
                   :to="{
-                    name: 'DatasetApiManagePage',
+                    name: 'DatasetIntegrationNewPage',
                     params: { slug },
                   }"
                 >
-                  {{ !isNil(dataset.integration.id) ? "Manage API Link" : "Add API Link" }}
+                  Add API Link
+                </v-btn>
+                <v-btn
+                  v-else
+                  color="primary"
+                  :to="{
+                    name: 'DatasetIntegrationManagePage',
+                    params: { slug },
+                  }"
+                >
+                  Manage API Link
                 </v-btn>
               </v-col>
             </v-row>

--- a/web/src/components/users/UserAttributeTextField.vue
+++ b/web/src/components/users/UserAttributeTextField.vue
@@ -28,7 +28,7 @@ const props = withDefaults(
 )
 
 const { modelValue: userId } = toRefs(props)
-const { user, isLoading } = useUser(userId)
+const { user, isLoading } = useUser(userId, { withDeleted: true })
 
 const fieldValue = computed(() => {
   if (isNil(props.modelValue)) {

--- a/web/src/pages/DatasetIntegrationManagePage.vue
+++ b/web/src/pages/DatasetIntegrationManagePage.vue
@@ -1,0 +1,100 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col
+        cols="0"
+        md="3"
+      ></v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <h2>Link External API</h2>
+      </v-col>
+    </v-row>
+
+    <v-row>
+      <v-col
+        cols="0"
+        md="3"
+      ></v-col>
+      <v-col
+        cols="12"
+        md="6"
+      >
+        <!-- TODO: make the skeleton loader an external component that matches the form -->
+        <v-skeleton-loader
+          v-if="isNil(dataset) || isNil(dataset.integration.id)"
+          type="card"
+        />
+        <DatasetIntegrationUpdateForm
+          v-else
+          :dataset-id="dataset.id"
+          :dataset-integration-id="dataset.integration.id"
+          @completed="returnToParentPage"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+import { toRefs } from "vue"
+import { useRouter } from "vue-router"
+import { isNil } from "lodash"
+
+import useBreadcrumbs from "@/use/use-breadcrumbs"
+import useDataset from "@/use/use-dataset"
+
+import DatasetIntegrationUpdateForm from "@/components/dataset-integrations/DatasetIntegrationUpdateForm.vue"
+
+const props = defineProps({
+  slug: {
+    type: String,
+    required: true,
+  },
+})
+
+const { slug } = toRefs(props)
+const { dataset } = useDataset(slug)
+const router = useRouter()
+
+function returnToParentPage() {
+  router.push({
+    name: "DatasetDescriptionManagePage",
+    params: { slug: props.slug },
+  })
+}
+
+const { setBreadcrumbs } = useBreadcrumbs()
+
+setBreadcrumbs([
+  {
+    title: "Datasets",
+    to: {
+      name: "DatasetsPage",
+    },
+  },
+  {
+    title: "Description",
+    to: {
+      name: "DatasetDescriptionReadPage",
+      params: { slug: props.slug },
+    },
+  },
+  {
+    title: "Manage",
+    to: {
+      name: "DatasetDescriptionManagePage",
+      params: { slug: props.slug },
+    },
+  },
+  {
+    title: "Link API",
+    to: {
+      name: "DatasetIntegrationManagePage",
+      params: { slug: props.slug },
+    },
+  },
+])
+</script>

--- a/web/src/pages/DatasetIntegrationNewPage.vue
+++ b/web/src/pages/DatasetIntegrationNewPage.vue
@@ -27,16 +27,10 @@
           v-if="isNil(dataset)"
           type="card"
         />
-        <DatasetIntegrationUpdateForm
-          v-else-if="!isNil(dataset.integration.id)"
-          :dataset-id="dataset.id"
-          :dataset-integration-id="dataset.integration.id"
-          @completed="returnToParentPage"
-        />
         <DatasetIntegrationCreateForm
           v-else
           :dataset-id="dataset.id"
-          @completed="refresh"
+          @completed="goToManagePage"
         />
       </v-col>
     </v-row>
@@ -52,7 +46,6 @@ import useBreadcrumbs from "@/use/use-breadcrumbs"
 import useDataset from "@/use/use-dataset"
 
 import DatasetIntegrationCreateForm from "@/components/dataset-integrations/DatasetIntegrationCreateForm.vue"
-import DatasetIntegrationUpdateForm from "@/components/dataset-integrations/DatasetIntegrationUpdateForm.vue"
 
 const props = defineProps({
   slug: {
@@ -62,12 +55,12 @@ const props = defineProps({
 })
 
 const { slug } = toRefs(props)
-const { dataset, refresh } = useDataset(slug)
+const { dataset } = useDataset(slug)
 const router = useRouter()
 
-function returnToParentPage() {
+function goToManagePage() {
   router.push({
-    name: "DatasetDescriptionManagePage",
+    name: "DatasetIntegrationManagePage",
     params: { slug: props.slug },
   })
 }
@@ -98,7 +91,7 @@ setBreadcrumbs([
   {
     title: "Link API",
     to: {
-      name: "DatasetApiManagePage",
+      name: "DatasetIntegrationNewPage",
       params: { slug: props.slug },
     },
   },

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -83,9 +83,16 @@ const routes: RouteRecordRaw[] = [
       },
       // TODO: Make this page a tab in the DatasetLayout, after I make that pattern more flexible
       {
-        path: "datasets/:slug/api/manage",
-        name: "DatasetApiManagePage",
-        component: () => import("@/pages/DatasetApiManagePage.vue"),
+        path: "datasets/:slug/integration/new",
+        name: "DatasetIntegrationNewPage",
+        component: () => import("@/pages/DatasetIntegrationNewPage.vue"),
+        props: true,
+      },
+      // TODO: Make this page a tab in the DatasetLayout, after I make that pattern more flexible
+      {
+        path: "datasets/:slug/integration/manage",
+        name: "DatasetIntegrationManagePage",
+        component: () => import("@/pages/DatasetIntegrationManagePage.vue"),
         props: true,
       },
       {


### PR DESCRIPTION
Relates to:
- [0003, IDP and Storing Data, 2024-03-27](https://docs.google.com/document/d/1S6BPUqVuYNLXMOXME36os2i0LnrpRyCmWE5ihXqGix0/edit#heading=h.f4pmdcovj4q5)
- Partially completes https://github.com/icefoganalytics/internal-data-portal/issues/92

# Context

## Problem Statement

Amalgamating data from various sources in a consistent way comes with several caveats in regards to data normalization and storage. 

Currently the data portal is doing a full import of an external dataset and this may not scale well, or add much value to end users.

End users will use the platform to gain a quick preview of the dataset, and get an example of data quality. If they want more data, or a real-time interaction with the dataset, they will interact with the source dataset directly.

## Summary

- [x] Store local preview of data (100 records)
- [ ] Give end users the ability to refresh the current dataset preview.
- [x] Give ability to download CSV of fresh copy of dataset that supports filtering.
- [x] CSV download function operates against the source dataset.
- [x] Filters on previews will operate differently when applied to CSV download of source dataset.
- [ ] Provide ability to add local datasets that aren’t previews.	

## New Data to Track

* Total dataset size (Bytes)
* Total number of records
* Time dataset takes to return data

# Implementation

Rework CSV download to return data directly from source.
Rework dataset integration to support "activate" function that refresh metadata and truncated data.
Switch to true download streaming, with the advantage that download now starts almost instantly, even if it now takes 30+seconds to actually complete.

# Screenshots

Pretty much the same as before
![image](https://github.com/icefoganalytics/internal-data-portal/assets/23045206/3145aa7d-bfef-42a1-a897-cd89364cc323)

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Go to a dataset or create one.
5. Go to the dataset description tab, click the "Link External API" button (or Manage API Link button), and add an API integration.
6. Add some fields to the dataset in the Fields tab.
7. Go to the Visualize tab and download the CSV. Download will start quickly, but take a 30+seconds to complete, or maybe fail, because of external API flakiness.
