### PR TITLE
Fix Scope Chaining Usage In Controllers

### DIFF
--- a/api/src/controllers/dataset-entries-controller.ts
+++ b/api/src/controllers/dataset-entries-controller.ts
@@ -4,6 +4,7 @@ import { createReadStream } from "fs"
 
 import { Dataset, DatasetEntry } from "@/models"
 import { DatasetEntriesPolicy } from "@/policies"
+import { BaseScopeOptions } from "@/policies/base-policy"
 import { CreateCsvService } from "@/services/dataset-entries"
 
 import BaseController from "@/controllers/base-controller"
@@ -15,20 +16,19 @@ export class DatasetEntriesController extends BaseController {
     const where = this.query.where as WhereOptions<DatasetEntry>
     const filters = this.query.filters as Record<string, unknown>
 
-    const scopedDatasetEntries = DatasetEntriesPolicy.applyScope(DatasetEntry, this.currentUser)
-
-    let filteredDatasetEntries = scopedDatasetEntries
+    const scopes: BaseScopeOptions[] = []
     if (!isEmpty(filters)) {
       Object.entries(filters).forEach(([key, value]) => {
-        filteredDatasetEntries = filteredDatasetEntries.scope({ method: [key, value] })
+        scopes.push({ method: [key, value] })
       })
     }
+    const scopedDatasetEntries = DatasetEntriesPolicy.applyScope(scopes, this.currentUser)
 
     if (this.format === "csv") {
-      return this.respondWithCsv(filteredDatasetEntries, where)
+      return this.respondWithCsv(scopedDatasetEntries, where)
     } else {
-      const totalCount = await filteredDatasetEntries.count({ where })
-      const datasetEntries = await filteredDatasetEntries.findAll({
+      const totalCount = await scopedDatasetEntries.count({ where })
+      const datasetEntries = await scopedDatasetEntries.findAll({
         where,
         limit: this.pagination.limit,
         offset: this.pagination.offset,

--- a/api/src/controllers/dataset-entries-controller.ts
+++ b/api/src/controllers/dataset-entries-controller.ts
@@ -13,13 +13,15 @@ import BaseController from "@/controllers/base-controller"
 export class DatasetEntriesController extends BaseController {
   async index() {
     const where = this.query.where as WhereOptions<DatasetEntry>
-    const searchToken = this.query.searchToken as string
+    const filters = this.query.filters as Record<string, unknown>
 
     const scopedDatasetEntries = DatasetEntriesPolicy.applyScope(DatasetEntry, this.currentUser)
 
     let filteredDatasetEntries = scopedDatasetEntries
-    if (!isEmpty(searchToken)) {
-      filteredDatasetEntries = scopedDatasetEntries.scope({ method: ["search", searchToken] })
+    if (!isEmpty(filters)) {
+      Object.entries(filters).forEach(([key, value]) => {
+        filteredDatasetEntries = filteredDatasetEntries.scope({ method: [key, value] })
+      })
     }
 
     if (this.format === "csv") {

--- a/api/src/controllers/dataset-fields-controller.ts
+++ b/api/src/controllers/dataset-fields-controller.ts
@@ -12,7 +12,7 @@ export class DatasetFieldsController extends BaseController {
   async index() {
     const where = this.query.where as WhereOptions<DatasetField>
 
-    const scopedDatasetFields = DatasetFieldsPolicy.applyScope(DatasetField, this.currentUser)
+    const scopedDatasetFields = DatasetFieldsPolicy.applyScope([], this.currentUser)
 
     const totalCount = await scopedDatasetFields.count({ where })
     const datasetFields = await scopedDatasetFields.findAll({
@@ -90,7 +90,9 @@ export class DatasetFieldsController extends BaseController {
       await DestroyService.perform(datasetField, this.currentUser)
       return this.response.status(204).end()
     } catch (error) {
-      return this.response.status(422).json({ message: `Dataset field destruction failed: ${error}` })
+      return this.response
+        .status(422)
+        .json({ message: `Dataset field destruction failed: ${error}` })
     }
   }
 

--- a/api/src/controllers/datasets-controller.ts
+++ b/api/src/controllers/datasets-controller.ts
@@ -1,4 +1,4 @@
-import { WhereOptions } from "sequelize"
+import { Op, WhereOptions } from "sequelize"
 import { isEmpty, isNil } from "lodash"
 
 import { Dataset } from "@/models"
@@ -142,8 +142,12 @@ export class DatasetsController extends BaseController {
         "integration",
         "stewardship",
         "accessGrants",
-        "accessRequests",
         "visualizationControl",
+        {
+          association: "accessRequests",
+          where: { revokedAt: { [Op.is]: null } },
+          required: false,
+        },
       ],
     })
 

--- a/api/src/controllers/datasets-controller.ts
+++ b/api/src/controllers/datasets-controller.ts
@@ -2,6 +2,7 @@ import { WhereOptions } from "sequelize"
 import { isEmpty, isNil } from "lodash"
 
 import { Dataset } from "@/models"
+import { BaseScopeOptions } from "@/policies/base-policy"
 import { DatasetsPolicy } from "@/policies"
 import { CreateService, UpdateService } from "@/services/datasets"
 import { ShowSerializer, TableSerializer } from "@/serializers/datasets"
@@ -13,17 +14,16 @@ export class DatasetsController extends BaseController {
     const where = this.query.where as WhereOptions<Dataset>
     const filters = this.query.filters as Record<string, unknown>
 
-    const scopedDatasets = DatasetsPolicy.applyScope(Dataset, this.currentUser)
-
-    let filteredDatasets = scopedDatasets
+    const scopes: BaseScopeOptions[] = []
     if (!isEmpty(filters)) {
       Object.entries(filters).forEach(([key, value]) => {
-        filteredDatasets = filteredDatasets.scope({ method: [key, value] })
+        scopes.push({ method: [key, value] })
       })
     }
+    const scopedDatasets = DatasetsPolicy.applyScope(scopes, this.currentUser)
 
-    const totalCount = await filteredDatasets.count({ where })
-    const datasets = await filteredDatasets.findAll({
+    const totalCount = await scopedDatasets.count({ where })
+    const datasets = await scopedDatasets.findAll({
       where,
       limit: this.pagination.limit,
       offset: this.pagination.offset,

--- a/api/src/controllers/users-controller.ts
+++ b/api/src/controllers/users-controller.ts
@@ -1,8 +1,9 @@
-import { ModelStatic, WhereOptions } from "sequelize"
+import { WhereOptions } from "sequelize"
 import { isEmpty, isNil } from "lodash"
 
 import { User } from "@/models"
 import { UserSerializers } from "@/serializers"
+import { BaseScopeOptions } from "@/policies/base-policy"
 import { UsersPolicy } from "@/policies"
 import { CreateService, DestroyService, UpdateService } from "@/services/users"
 
@@ -13,12 +14,13 @@ export class UsersController extends BaseController {
     const where = this.query.where as WhereOptions<User>
     const filters = this.query.filters as Record<string, unknown>
 
-    let filteredUsers: ModelStatic<User> = User
+    const scopes: BaseScopeOptions[] = []
     if (!isEmpty(filters)) {
       Object.entries(filters).forEach(([key, value]) => {
-        filteredUsers = filteredUsers.scope({ method: [key, value] })
+        scopes.push({ method: [key, value] })
       })
     }
+    const filteredUsers = User.scope(scopes)
 
     const totalCount = await filteredUsers.count({ where })
     const users = await filteredUsers.findAll({

--- a/api/src/controllers/users/search-controller.ts
+++ b/api/src/controllers/users/search-controller.ts
@@ -1,7 +1,8 @@
-import { ModelStatic, Op, WhereOptions, col, fn, where } from "sequelize"
+import { Op, WhereOptions, col, fn, where } from "sequelize"
 import { isEmpty, isNil } from "lodash"
 
 import { User } from "@/models"
+import { BaseScopeOptions } from "@/policies/base-policy"
 import { UserSerializers } from "@/serializers"
 
 import BaseController from "@/controllers/base-controller"
@@ -10,12 +11,13 @@ export class SearchController extends BaseController {
   async index() {
     const filters = this.query.filters as Record<string, unknown>
 
-    let filteredUsers: ModelStatic<User> = User
+    const scopes: BaseScopeOptions[] = []
     if (!isEmpty(filters)) {
       Object.entries(filters).forEach(([key, value]) => {
-        filteredUsers = filteredUsers.scope({ method: [key, value] })
+        scopes.push({ method: [key, value] })
       })
     }
+    const filteredUsers = User.scope(scopes)
 
     const searchQuery = this.buildSearchQuery()
     const totalCount = await filteredUsers.count({ where: searchQuery })

--- a/api/src/models/dataset-entry.ts
+++ b/api/src/models/dataset-entry.ts
@@ -11,6 +11,7 @@ import {
   NonAttribute,
   Op,
 } from "sequelize"
+import { isEmpty } from "lodash"
 
 import sequelize from "@/db/db-client"
 
@@ -117,16 +118,20 @@ DatasetEntry.init(
     ],
     scopes: {
       search(searchToken: string) {
+        if (isEmpty(searchToken)) {
+          return {}
+        }
+
         return {
           where: {
             id: {
               [Op.in]: datasetEntriesSearch(),
-            }
+            },
           },
           replacements: {
             searchTokenWildcard: `%${searchToken}%`,
             searchToken,
-          }
+          },
         }
       },
     },

--- a/api/src/policies/README.md
+++ b/api/src/policies/README.md
@@ -1,0 +1,268 @@
+# Policies
+
+Policies are used to control access to data in a controller, before it is returned to the client.
+Polices can be used in the following ways:
+
+1. Build a policy instance and check the controller action matching boolean function.
+   Controller#update -> Policy#update
+
+   ```ts
+   export class AccessGrantsController extends BaseController {
+     async update() {
+       const accessGrant = await this.loadAccessGrant()
+       if (isNil(accessGrant)) {
+         return this.response.status(404).json({ message: "Access grant not found." })
+       }
+
+       const policy = this.buildPolicy(accessGrant)
+       if (!policy.update()) {
+         return this.response
+           .status(403)
+           .json({ message: "You are not authorized to update access grants on this dataset." })
+       }
+
+       const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
+       try {
+         const updatedAccessGrant = await UpdateService.perform(
+           accessGrant,
+           permittedAttributes,
+           this.currentUser
+         )
+         return this.response.status(200).json({ accessGrant: updatedAccessGrant })
+       } catch (error) {
+         return this.response.status(422).json({ message: `Access grant update failed: ${error}` })
+       }
+     }
+
+     private async loadAccessGrant(): Promise<AccessGrant | null> {
+       return AccessGrant.findByPk(this.params.accessGrantId)
+     }
+
+     private buildPolicy(accessGrant: AccessGrant) {
+       return new AccessGrantsPolicy(this.currentUser, accessGrant)
+     }
+   }
+   ```
+
+2. The previous example also demostrates a second way of using policies. The "permitted attributes" pattern. A policy can also be used to provide an "allow list" of attributes that a user is allowed to submit for a given controller action.
+
+   ```ts
+   export class AccessGrantsPolicy extends BasePolicy<AccessGrant> {
+     permittedAttributes(): Path[] {
+       return ["supportId", "grantLevel", "accessType", "isProjectDescriptionRequired"]
+     }
+   }
+   ```
+
+3. Policies can also be used to restrict the results of an "index" or list action in a controller.
+   In this case a bunch of scoping conditions are built up, and then passed to the "apply scope" function. This produces a query that, when executed, will only return the records that the current user is allowed to see.
+
+   ```ts
+   export class AccessGrantsController extends BaseController {
+     async index() {
+       const where = this.query.where as WhereOptions<AccessGrant>
+       const filters = this.query.filters as Record<string, unknown>
+
+       const scopes: BaseScopeOptions[] = []
+       if (!isEmpty(filters)) {
+         Object.entries(filters).forEach(([key, value]) => {
+           scopes.push({ method: [key, value] })
+         })
+       }
+       const scopedAccessGrants = AccessGrantsPolicy.applyScope(scopes, this.currentUser)
+
+       const totalCount = await scopedAccessGrants.count({ where })
+       const accessGrants = await scopedAccessGrants.findAll({
+         where,
+         limit: this.pagination.limit,
+         offset: this.pagination.offset,
+       })
+
+       return this.response.json({ accessGrants, totalCount })
+     }
+   }
+   ```
+
+## Policy#policyScope
+
+The `policyScope` method is used to add a scope to the given model. This scope is permanently added to the model, though it likely shouldn't be used outside of the policy.
+
+i.e.
+
+```ts
+export class AccessRequestsPolicy extends PolicyFactory(AccessRequest) {
+  static policyScope(user: User): FindOptions<Attributes<AccessRequest>> {
+    if (user.isSystemAdmin || user.isBusinessAnalyst) {
+      return {}
+    }
+
+    if (user.isDataOwner) {
+      return {
+        include: [
+          {
+            association: "dataset",
+            where: {
+              ownerId: user.id,
+            },
+          },
+        ],
+      }
+    }
+
+    return {
+      where: {
+        requestorId: user.id,
+      },
+    }
+  }
+}
+```
+
+can be considered equivalent to
+
+```ts
+AccessReqeuest.addScope("policyScope", (user: User) => {
+  if (user.isSystemAdmin || user.isBusinessAnalyst) {
+    return {}
+  }
+
+  if (user.isDataOwner) {
+    return {
+      include: [
+        {
+          association: "dataset",
+          where: {
+            ownerId: user.id,
+          },
+        },
+      ],
+    }
+  }
+
+  return {
+    where: {
+      requestorId: user.id,
+    },
+  }
+})
+```
+
+# Full Example
+
+Here is a simple example of a controller using a policy to control access to a resource.
+The full cases might be more complex, but the "policy" pattern leaves space for that complexity to exist without cluttering the controller.
+
+```ts
+export class AccessGrantsController extends BaseController {
+  async index() {
+    const where = this.query.where as WhereOptions<AccessGrant>
+    const filters = this.query.filters as Record<string, unknown>
+
+    const scopes: BaseScopeOptions[] = []
+    if (!isEmpty(filters)) {
+      Object.entries(filters).forEach(([key, value]) => {
+        scopes.push({ method: [key, value] })
+      })
+    }
+    const scopedAccessGrants = AccessGrantsPolicy.applyScope(scopes, this.currentUser)
+
+    const totalCount = await scopedAccessGrants.count({ where })
+    const accessGrants = await scopedAccessGrants.findAll({
+      where,
+      limit: this.pagination.limit,
+      offset: this.pagination.offset,
+    })
+
+    return this.response.json({ accessGrants, totalCount })
+  }
+
+  async create() {
+    const accessGrant = await this.buildAccessGrant()
+    if (isNil(accessGrant)) {
+      return this.response.status(404).json({ message: "Dataset not found." })
+    }
+
+    const policy = this.buildPolicy(accessGrant)
+    if (!policy.create()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to add access grants for this dataset." })
+    }
+
+    const permittedAttributes = policy.permitAttributesForCreate(this.request.body)
+    try {
+      const accessGrant = await CreateService.perform(permittedAttributes, this.currentUser)
+      return this.response.status(201).json({ accessGrant })
+    } catch (error) {
+      return this.response.status(422).json({ message: `Access grant creation failed: ${error}` })
+    }
+  }
+
+  async update() {
+    const accessGrant = await this.loadAccessGrant()
+    if (isNil(accessGrant)) {
+      return this.response.status(404).json({ message: "Access grant not found." })
+    }
+
+    const policy = this.buildPolicy(accessGrant)
+    if (!policy.update()) {
+      return this.response
+        .status(403)
+        .json({ message: "You are not authorized to update access grants on this dataset." })
+    }
+
+    const permittedAttributes = policy.permitAttributesForUpdate(this.request.body)
+    try {
+      const updatedAccessGrant = await UpdateService.perform(
+        accessGrant,
+        permittedAttributes,
+        this.currentUser
+      )
+      return this.response.status(200).json({ accessGrant: updatedAccessGrant })
+    } catch (error) {
+      return this.response.status(422).json({ message: `Access grant update failed: ${error}` })
+    }
+  }
+
+  private async buildAccessGrant(): Promise<AccessGrant> {
+    return AccessGrant.build(this.request.body)
+  }
+
+  private async loadAccessGrant(): Promise<AccessGrant | null> {
+    return AccessGrant.findByPk(this.params.accessGrantId)
+  }
+
+  private buildPolicy(accessGrant: AccessGrant) {
+    return new AccessGrantsPolicy(this.currentUser, accessGrant)
+  }
+}
+```
+
+and the policy
+
+```ts
+export class AccessGrantsPolicy extends BasePolicy<AccessGrant> {
+  create(): boolean {
+    // some code that might returns true
+    return false
+  }
+
+  update(): boolean {
+    // some code that might returns true
+    return false
+  }
+
+  destroy(): boolean {
+    // some code that might returns true
+    return false
+  }
+
+  permittedAttributes(): Path[] {
+    return ["supportId", "grantLevel", "accessType", "isProjectDescriptionRequired"]
+  }
+
+  permittedAttributesForCreate(): Path[] {
+    return ["datasetId", ...this.permittedAttributes()]
+  }
+}
+```

--- a/api/src/policies/base-policy.ts
+++ b/api/src/policies/base-policy.ts
@@ -33,6 +33,11 @@ export class BasePolicy<M extends Model> {
     return false
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static policyScope<M extends Model>(user: User): FindOptions<Attributes<M>> {
+    throw new Error("Derived classes must implement policyScope method")
+  }
+
   permitAttributes(record: Partial<M>): Partial<M> {
     return deepPick(record, this.permittedAttributes())
   }
@@ -89,8 +94,8 @@ export type BaseScopeOptions = string | ScopeOptions
 
 export const POLICY_SCOPE_NAME = "policyScope"
 
-export function PolicyFactory<M extends Model>(modelClass: ModelStatic<M>) {
-  const policyClass = class Policy extends BasePolicy<M> {
+export function PolicyFactory<M extends Model, T extends Model = M>(modelClass: ModelStatic<M>) {
+  const policyClass = class Policy extends BasePolicy<T> {
     static applyScope(scopes: BaseScopeOptions[], user: User): ModelStatic<M> {
       this.ensurePolicyScope()
 
@@ -107,11 +112,6 @@ export function PolicyFactory<M extends Model>(modelClass: ModelStatic<M>) {
       }
 
       modelClass.addScope(POLICY_SCOPE_NAME, this.policyScope.bind(modelClass))
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    static policyScope(user: User): FindOptions<Attributes<M>> {
-      throw new Error("Derived classes must implement policyScope method")
     }
   }
 

--- a/api/src/policies/dataset-entries-policy.ts
+++ b/api/src/policies/dataset-entries-policy.ts
@@ -1,4 +1,4 @@
-import { ModelStatic, Op } from "sequelize"
+import { Attributes, FindOptions, Op } from "sequelize"
 
 import { DatasetEntry, User } from "@/models"
 import { AccessTypes } from "@/models/access-grant"
@@ -8,13 +8,12 @@ import {
   datasetsWithApprovedAccessRequestsFor,
 } from "@/models/datasets"
 
-import BasePolicy from "@/policies/base-policy"
+import { PolicyFactory } from "@/policies/base-policy"
 
-export class DatasetEntriesPolicy extends BasePolicy<DatasetEntry> {
-  // TODO: move this code to a shared location, somewhere
-  static applyScope(modelClass: ModelStatic<DatasetEntry>, user: User): ModelStatic<DatasetEntry> {
+export class DatasetEntriesPolicy extends PolicyFactory(DatasetEntry) {
+  static policyScope(user: User): FindOptions<Attributes<DatasetEntry>> {
     if (user.isSystemAdmin || user.isBusinessAnalyst) {
-      return modelClass
+      return {}
     }
 
     const datasetsAccessibleViaOpenAccessGrantsByUserQuery = datasetsAccessibleViaAccessGrantsBy(
@@ -25,7 +24,7 @@ export class DatasetEntriesPolicy extends BasePolicy<DatasetEntry> {
       datasetsWithApprovedAccessRequestsFor(user)
     if (user.isDataOwner) {
       const datasetsAccessibleViaOwnerQuery = datasetsAccessibleViaOwner(user)
-      return modelClass.scope({
+      return {
         where: {
           datasetId: {
             [Op.or]: [
@@ -35,10 +34,10 @@ export class DatasetEntriesPolicy extends BasePolicy<DatasetEntry> {
             ],
           },
         },
-      })
+      }
     }
 
-    return modelClass.scope({
+    return {
       where: {
         datasetId: {
           [Op.or]: [
@@ -47,7 +46,7 @@ export class DatasetEntriesPolicy extends BasePolicy<DatasetEntry> {
           ],
         },
       },
-    })
+    }
   }
 }
 

--- a/api/tests/controllers/dataset-entries-controller.test.ts
+++ b/api/tests/controllers/dataset-entries-controller.test.ts
@@ -1,0 +1,314 @@
+import request from "supertest"
+
+import app from "@/app"
+import { RoleTypes } from "@/models/role"
+import { DatasetField } from "@/models"
+
+import {
+  accessGrantFactory,
+  datasetEntryFactory,
+  datasetFactory,
+  datasetFieldFactory,
+  roleFactory,
+  userFactory,
+  userGroupFactory,
+  userGroupMembershipFactory,
+  visualizationControlFactory,
+} from "@/factories"
+
+import { mockCurrentUser } from "@/support"
+import { UserGroupTypes } from "@/models/user-groups"
+import { AccessTypes, GrantLevels } from "@/models/access-grant"
+
+describe("api/src/controllers/dataset-entries-controller.ts", () => {
+  describe("DatasetEntriesController", () => {
+    describe("#index", () => {
+      test("when open access, and filter applied, limits by filter", async () => {
+        // Arrange
+        const department = await userGroupFactory.create({ type: UserGroupTypes.DEPARTMENT })
+        const currentUserGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const datasetOwnerGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const userRole = roleFactory.build({ role: RoleTypes.USER })
+        const currentUser = await userFactory
+          .associations({
+            roles: [userRole],
+            groupMembership: currentUserGroupMembership,
+          })
+          .transient({
+            include: ["roles", "groupMembership"],
+          })
+          .create()
+        mockCurrentUser(currentUser)
+
+        const dataOwner = await userFactory
+          .associations({
+            groupMembership: datasetOwnerGroupMembership,
+          })
+          .create()
+        const accessGrant = accessGrantFactory.build({
+          creatorId: dataOwner.id,
+          grantLevel: GrantLevels.GOVERNMENT_WIDE,
+          accessType: AccessTypes.OPEN_ACCESS,
+        })
+        const dataset = await datasetFactory
+          .associations({
+            accessGrants: [accessGrant],
+          })
+          .create({
+            creatorId: dataOwner.id,
+            ownerId: dataOwner.id,
+          })
+        await visualizationControlFactory.create({
+          datasetId: dataset.id,
+        })
+        await datasetFieldFactory.create({
+          datasetId: dataset.id,
+          name: "email",
+          dataType: DatasetField.DataTypes.TEXT,
+        })
+        const datasetEntry1 = await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Marlen@test.com" },
+        })
+        const datasetEntry2 = await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Mark@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Mandy@test.com" },
+        })
+
+        // Act
+        const response = await request(app)
+          .get("/api/dataset-entries")
+          .query({
+            filters: {
+              search: "mar",
+            },
+          })
+
+        // Assert
+        expect.assertions(2)
+        expect(response.status).toEqual(200)
+        expect(response.body).toEqual({
+          datasetEntries: [
+            expect.objectContaining({
+              id: datasetEntry1.id,
+              jsonData: { email: "Marlen@test.com" },
+            }),
+            expect.objectContaining({
+              id: datasetEntry2.id,
+              jsonData: { email: "Mark@test.com" },
+            }),
+          ],
+          totalCount: 2,
+        })
+      })
+
+      test("when screened access, and filter is applied, limits all access", async () => {
+        // Arrange
+        const department = await userGroupFactory.create({ type: UserGroupTypes.DEPARTMENT })
+        const currentUserGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const datasetOwnerGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const userRole = roleFactory.build({ role: RoleTypes.USER })
+        const currentUser = await userFactory
+          .associations({
+            roles: [userRole],
+            groupMembership: currentUserGroupMembership,
+          })
+          .transient({
+            include: ["roles", "groupMembership"],
+          })
+          .create()
+        mockCurrentUser(currentUser)
+
+        const dataOwner = await userFactory
+          .associations({
+            groupMembership: datasetOwnerGroupMembership,
+          })
+          .create()
+        const accessGrant = accessGrantFactory.build({
+          creatorId: dataOwner.id,
+          grantLevel: GrantLevels.GOVERNMENT_WIDE,
+          accessType: AccessTypes.SCREENED_ACCESS,
+        })
+        const dataset = await datasetFactory
+          .associations({
+            accessGrants: [accessGrant],
+          })
+          .create({
+            creatorId: dataOwner.id,
+            ownerId: dataOwner.id,
+          })
+        await visualizationControlFactory.create({
+          datasetId: dataset.id,
+        })
+        await datasetFieldFactory.create({
+          datasetId: dataset.id,
+          name: "email",
+          dataType: DatasetField.DataTypes.TEXT,
+        })
+        await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Marlen@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Mark@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: dataset.id,
+          jsonData: { email: "Mandy@test.com" },
+        })
+
+        // Act
+        const response = await request(app)
+          .get("/api/dataset-entries")
+          .query({
+            filters: {
+              search: "mar",
+            },
+          })
+
+        // Assert
+        expect.assertions(2)
+        expect(response.status).toEqual(200)
+        expect(response.body).toEqual({
+          datasetEntries: [],
+          totalCount: 0,
+        })
+      })
+
+      test("when some open access and some screened access, and filter applied, limits by filter and by access", async () => {
+        // Arrange
+        const department = await userGroupFactory.create({ type: UserGroupTypes.DEPARTMENT })
+        const currentUserGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const datasetOwnerGroupMembership = userGroupMembershipFactory.build({
+          departmentId: department.id,
+        })
+        const userRole = roleFactory.build({ role: RoleTypes.USER })
+        const currentUser = await userFactory
+          .associations({
+            roles: [userRole],
+            groupMembership: currentUserGroupMembership,
+          })
+          .transient({
+            include: ["roles", "groupMembership"],
+          })
+          .create()
+        mockCurrentUser(currentUser)
+
+        const dataOwner = await userFactory
+          .associations({
+            groupMembership: datasetOwnerGroupMembership,
+          })
+          .create()
+        const openAccessGrant = accessGrantFactory.build({
+          creatorId: dataOwner.id,
+          grantLevel: GrantLevels.GOVERNMENT_WIDE,
+          accessType: AccessTypes.OPEN_ACCESS,
+        })
+
+        const accessibleDataset = await datasetFactory
+          .associations({
+            accessGrants: [openAccessGrant],
+          })
+          .create({
+            creatorId: dataOwner.id,
+            ownerId: dataOwner.id,
+          })
+        await visualizationControlFactory.create({
+          datasetId: accessibleDataset.id,
+        })
+        await datasetFieldFactory.create({
+          datasetId: accessibleDataset.id,
+          name: "email",
+          dataType: DatasetField.DataTypes.TEXT,
+        })
+        const datasetEntry1 = await datasetEntryFactory.create({
+          datasetId: accessibleDataset.id,
+          jsonData: { email: "Marlen@test.com" },
+        })
+        const datasetEntry2 = await datasetEntryFactory.create({
+          datasetId: accessibleDataset.id,
+          jsonData: { email: "Mark@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: accessibleDataset.id,
+          jsonData: { email: "Mandy@test.com" },
+        })
+
+        const screenedAccessGrant = accessGrantFactory.build({
+          creatorId: dataOwner.id,
+          grantLevel: GrantLevels.GOVERNMENT_WIDE,
+          accessType: AccessTypes.SCREENED_ACCESS,
+        })
+        const inaccessibleDataset = await datasetFactory
+          .associations({
+            accessGrants: [screenedAccessGrant],
+          })
+          .create({
+            creatorId: dataOwner.id,
+            ownerId: dataOwner.id,
+          })
+        await visualizationControlFactory.create({
+          datasetId: inaccessibleDataset.id,
+        })
+        await datasetFieldFactory.create({
+          datasetId: inaccessibleDataset.id,
+          name: "email",
+          dataType: DatasetField.DataTypes.TEXT,
+        })
+        await datasetEntryFactory.create({
+          datasetId: inaccessibleDataset.id,
+          jsonData: { email: "Marlen@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: inaccessibleDataset.id,
+          jsonData: { email: "Mark@test.com" },
+        })
+        await datasetEntryFactory.create({
+          datasetId: inaccessibleDataset.id,
+          jsonData: { email: "Mandy@test.com" },
+        })
+
+        // Act
+        const response = await request(app)
+          .get("/api/dataset-entries")
+          .query({
+            filters: {
+              search: "mar",
+            },
+          })
+
+        // Assert
+        expect.assertions(2)
+        expect(response.status).toEqual(200)
+        expect(response.body).toEqual({
+          datasetEntries: [
+            expect.objectContaining({
+              id: datasetEntry1.id,
+              jsonData: { email: "Marlen@test.com" },
+            }),
+            expect.objectContaining({
+              id: datasetEntry2.id,
+              jsonData: { email: "Mark@test.com" },
+            }),
+          ],
+          totalCount: 2,
+        })
+      })
+    })
+  })
+})

--- a/api/tests/policies/access-requests-policy.test.ts
+++ b/api/tests/policies/access-requests-policy.test.ts
@@ -1,4 +1,3 @@
-import { AccessRequest } from "@/models"
 import { RoleTypes } from "@/models/role"
 
 import { AccessRequestsPolicy } from "@/policies"
@@ -55,7 +54,7 @@ describe("api/src/policies/access-requests-policy.ts", () => {
             accessGrantId: accessGrant2.id,
             requestorId: requestor2.id,
           })
-          const scopedQuery = AccessRequestsPolicy.applyScope(AccessRequest, requestingUser)
+          const scopedQuery = AccessRequestsPolicy.applyScope([], requestingUser)
 
           // Act
           const result = await scopedQuery.findAll()
@@ -72,7 +71,7 @@ describe("api/src/policies/access-requests-policy.ts", () => {
         }
       )
 
-      test("when user role is `data_owner`, it returns only records where the user is the dataset owner", async () => {
+      test.only("when user role is `data_owner`, it returns only records where the user is the dataset owner", async () => {
         // Arrange
         const role = roleFactory.build({ role: RoleTypes.DATA_OWNER })
         const requestingUser = await userFactory
@@ -111,13 +110,15 @@ describe("api/src/policies/access-requests-policy.ts", () => {
           accessGrantId: accessGrant2.id,
           requestorId: requestor2.id,
         })
-        const scopedQuery = AccessRequestsPolicy.applyScope(AccessRequest, requestingUser)
+        const scopedQuery = AccessRequestsPolicy.applyScope([], requestingUser)
 
         // Act
-        const result = await scopedQuery.findAll()
+        const result = await scopedQuery.findAll({
+          logging: console.log,
+        })
 
         // Assert
-        expect(result).toEqual([
+        expect(result.map((r) => r.dataValues)).toEqual([
           expect.objectContaining({
             id: accessRequest1.id,
           }),
@@ -163,7 +164,7 @@ describe("api/src/policies/access-requests-policy.ts", () => {
           accessGrantId: accessGrant2.id,
           requestorId: requestor2.id,
         })
-        const scopedQuery = AccessRequestsPolicy.applyScope(AccessRequest, requestingUser)
+        const scopedQuery = AccessRequestsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()

--- a/api/tests/policies/access-requests-policy.test.ts
+++ b/api/tests/policies/access-requests-policy.test.ts
@@ -113,9 +113,7 @@ describe("api/src/policies/access-requests-policy.ts", () => {
         const scopedQuery = AccessRequestsPolicy.applyScope([], requestingUser)
 
         // Act
-        const result = await scopedQuery.findAll({
-          logging: console.log,
-        })
+        const result = await scopedQuery.findAll()
 
         // Assert
         expect(result.map((r) => r.dataValues)).toEqual([

--- a/api/tests/policies/dataset-fields-policy.test.ts
+++ b/api/tests/policies/dataset-fields-policy.test.ts
@@ -37,7 +37,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
           const accessibleDatasetField = await datasetFieldFactory.create({
             datasetId: dataset.id,
           })
-          const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+          const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
           // Act
           const result = await scopedQuery.findAll()
@@ -84,7 +84,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: dataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -149,7 +149,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: inaccessibleDataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -219,7 +219,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: inaccessibleDataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -291,7 +291,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: inaccessibleDataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -351,7 +351,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: inaccessibleDataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -422,7 +422,7 @@ describe("api/src/policies/dataset-fields-policy.ts", () => {
         await datasetFieldFactory.create({
           datasetId: inaccessibleDataset.id,
         })
-        const scopedQuery = DatasetFieldsPolicy.applyScope(DatasetField, requestingUser)
+        const scopedQuery = DatasetFieldsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()

--- a/api/tests/policies/datasets-policy.test.ts
+++ b/api/tests/policies/datasets-policy.test.ts
@@ -47,7 +47,7 @@ describe("api/src/policies/datasets-policy.ts", () => {
             creatorId: datasetOwner.id,
             ownerId: datasetOwner.id,
           })
-          const scopedQuery = DatasetsPolicy.applyScope(Dataset, requestingUser)
+          const scopedQuery = DatasetsPolicy.applyScope([], requestingUser)
 
           // Act
           const result = await scopedQuery.findAll()
@@ -91,7 +91,7 @@ describe("api/src/policies/datasets-policy.ts", () => {
           creatorId: datasetOwner.id,
           ownerId: datasetOwner.id,
         })
-        const scopedQuery = DatasetsPolicy.applyScope(Dataset, requestingUser)
+        const scopedQuery = DatasetsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -149,7 +149,7 @@ describe("api/src/policies/datasets-policy.ts", () => {
             creatorId: datasetOwner.id,
             ownerId: datasetOwner.id,
           })
-        const scopedQuery = DatasetsPolicy.applyScope(Dataset, requestingUser)
+        const scopedQuery = DatasetsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -198,7 +198,7 @@ describe("api/src/policies/datasets-policy.ts", () => {
           creatorId: otherUser.id,
           ownerId: otherUser.id,
         })
-        const scopedQuery = DatasetsPolicy.applyScope(Dataset, requestingUser)
+        const scopedQuery = DatasetsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()
@@ -260,7 +260,7 @@ describe("api/src/policies/datasets-policy.ts", () => {
           creatorId: otherUser.id,
           ownerId: otherUser.id,
         })
-        const scopedQuery = DatasetsPolicy.applyScope(Dataset, requestingUser)
+        const scopedQuery = DatasetsPolicy.applyScope([], requestingUser)
 
         // Act
         const result = await scopedQuery.findAll()

--- a/web/src/api/dataset-entries-api.ts
+++ b/web/src/api/dataset-entries-api.ts
@@ -15,23 +15,24 @@ export type DatasetEntry = {
   updatedAt: string
 }
 
+export type DatasetEntriesFilters = {
+  search?: string
+}
+
 export const datasetEntriesApi = {
-  async list({
-    where,
-    searchToken,
-    page,
-    perPage,
-  }: {
-    where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
-    searchToken?: string
-    page?: number
-    perPage?: number
-  } = {}): Promise<{
+  async list(
+    params: {
+      where?: Record<string, unknown> // TODO: consider adding Sequelize types to front-end?
+      filters?: DatasetEntriesFilters
+      page?: number
+      perPage?: number
+    } = {}
+  ): Promise<{
     datasetEntries: DatasetEntry[]
     totalCount: number
   }> {
     const { data } = await http.get("/api/dataset-entries", {
-      params: { where, searchToken, page, perPage },
+      params,
     })
     return data
   },

--- a/web/src/components/dataset-entries/DatasetEntriesTable.vue
+++ b/web/src/components/dataset-entries/DatasetEntriesTable.vue
@@ -134,7 +134,9 @@ const datasetEntriesQuery = computed(() => ({
   where: {
     datasetId: props.datasetId,
   },
-  searchToken: searchToken.value,
+  filters: {
+    search: searchToken.value,
+  },
   perPage: itemsPerPage.value,
   page: page.value,
 }))

--- a/web/src/components/datasets/DataDescriptionCard.vue
+++ b/web/src/components/datasets/DataDescriptionCard.vue
@@ -33,7 +33,9 @@
         <v-chip
           v-else-if="
             !isNil(currentUserAccessGrant) &&
-            currentUserAccessGrant.accessType === AccessTypes.SELF_SERVE_ACCESS &&
+            [AccessTypes.SELF_SERVE_ACCESS, AccessTypes.SCREENED_ACCESS].includes(
+              currentUserAccessGrant.accessType
+            ) &&
             !isNil(currentUserAccessRequest) &&
             !isNil(currentUserAccessRequest.approvedAt)
           "

--- a/web/src/use/use-dataset-entries.ts
+++ b/web/src/use/use-dataset-entries.ts
@@ -1,13 +1,16 @@
 import { type Ref, reactive, toRefs, ref, unref, watch } from "vue"
 
-import datasetEntriesApi, { type DatasetEntry } from "@/api/dataset-entries-api"
+import datasetEntriesApi, {
+  type DatasetEntry,
+  type DatasetEntriesFilters,
+} from "@/api/dataset-entries-api"
 
-export { type DatasetEntry }
+export { type DatasetEntry, type DatasetEntriesFilters }
 
 export function useDatasetEntries(
   queryOptions: Ref<{
     where?: Record<string, unknown>
-    searchToken?: string
+    filters?: DatasetEntriesFilters
     page?: number
     perPage?: number
   }> = ref({})


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/101

Relates to:
- https://github.com/sequelize/sequelize/issues/17337

# Context

**Is your feature request related to a problem? Please describe.**
This code pattern does not work:
```ts
const where = this.query.where as WhereOptions<AccessRequest>
const filters = this.query.filters as Record<string, unknown>

const scopedAccessRequests = AccessRequestsPolicy.applyScope(AccessRequest, this.currentUser)

let filteredAccessRequests = scopedAccessRequests
if (!isEmpty(filters)) {
  Object.entries(filters).forEach(([key, value]) => {
    filteredAccessRequests = filteredAccessRequests.scope({ method: [key, value] })
  })
}

const totalCount = await filteredAccessRequests.count({ where })
const accessRequests = await filteredAccessRequests.findAll({
  where,
  limit: this.pagination.limit,
  offset: this.pagination.offset,
})
```

I thought you could chain `.scope` calls, but you cannot.
The current code completely removes policy scoping when filters are in effect.
Even if the scopes chained, the policy scope should be applied last to give it highest precedence.

**Describe the solution you'd like**
I want to be able to merge filter scopes and policy scopes in a safe way.

I've come up with a pattern that works
```ts
const where = this.query.where as WhereOptions<AccessRequest>
const filters = this.query.filters as Record<string, unknown>

const scopes: BaseScopeOptions[] = []
if (!isEmpty(filters)) {
  Object.entries(filters).forEach(([key, value]) => {
    scopes.push({ method: [key, value] })
  })
}
const scopedAccessRequests = AccessRequestsPolicy.applyScope(scopes, this.currentUser)

const totalCount = await scopedAccessRequests.count({ where })
const accessRequests = await scopedAccessRequests.findAll({
  where,
  limit: this.pagination.limit,
  offset: this.pagination.offset,
})
```

Given
```ts
// See api/node_modules/sequelize/types/model.d.ts -> Model -> scope
export type BaseScopeOptions = string | ScopeOptions

export const POLICY_SCOPE_NAME = "policyScope"

export function PolicyFactory<M extends Model>(modelClass: ModelStatic<M>) {
  const policyClass = class Policy extends BasePolicy<M> {
    static applyScope(scopes: BaseScopeOptions[], user: User): ModelStatic<M> {
      this.ensurePolicyScope()

      return modelClass.scope([...scopes, { method: [POLICY_SCOPE_NAME, user] }])
    }

    /**
     * Just in time scope creation for model class.
     * TODO: to have scope creation occur at definition time, instead of execution time.
     */
    static ensurePolicyScope() {
      if (Object.prototype.hasOwnProperty.call(modelClass.options.scopes, POLICY_SCOPE_NAME)) {
        return
      }

      modelClass.addScope(POLICY_SCOPE_NAME, this.policyScope.bind(modelClass))
    }

    // eslint-disable-next-line @typescript-eslint/no-unused-vars
    static policyScope(user: User): FindOptions<Attributes<M>> {
      throw new Error("Derived classes must implement policyScope method")
    }
  }

  return policyClass
}
```

**Describe alternatives you've considered**
Switching to Sequelize 7 does not fix this.
Switching to Rails would fix this, but I'm not allowed, and it would be a lot more work. 

**Additional context**
This issue is in effect in many of the repos I've been working on. I should definitely be writing more controller tests.
Why didn't I write more controller tests? Because I don't have a good pattern or framework for writing them yet, so they are very hard to write. Also Jest is very slow, switching to Vitest will make writing tests easier.

Effects these files:
- api/src/controllers/access-requests-controller.ts
- api/src/controllers/dataset-entries-controller.ts
- api/src/controllers/datasets-controller.ts
- api/src/controllers/users-controller.ts
- api/src/controllers/users/search-controller.ts

# Implementation

1. Add just in time policy scope creation from policy scope class method of policy.
    i.e. `Model.addScope('policyScope', Policy.policyScope.bind(Model))`
    I'd prefer to add the scope at load time, instead of run time, but can't figure out how to make that work.
2. Set up policy types will to complain unless you set:
    ```ts
    static policyScope(user: User): FindOptions<Attributes<SomeSpecificModel>> {}
    ```
    I'd prefer if the types were generated magically, but can't get it to work.
    At least this way they still fail correctly.
3. Found that I can't use scopes inside of other scopes, and decided that duplicating and inlining the code was the least painful way to fix it.
    The alternatives where:
    a. Add a method to the class that returns the scope, and use it in both places.
       Best if the scope is used in many places.
    b. `AccessRequest.scope({ method: ["withDatasetOwnerId", user.id] })._scope`.
       this is a hack loading info from a private method, and is not recommended.
       But it _would_ work, so good to be aware of it.
    c. Increase the complexity of the scope generator to handle returning a scope.
       This vastly increases the complexity of the code, and types, so probably not a good choice
       long term.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080
4. Navigate around, check that nothing is broken.
