### PR TITLE
Locking down user group info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.envrc
 .env.test
 .env.production
 

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ db/sapassword.env
 
 # DB Data
 db/data
+
+# Other
+note.md
+notes.md
+now.sql

--- a/api/src/policies/users-policy.ts
+++ b/api/src/policies/users-policy.ts
@@ -1,6 +1,5 @@
 import { Path } from "@/utils/deep-pick"
 import { User } from "@/models"
-import { RoleTypes } from "@/models/role"
 
 import BasePolicy from "@/policies/base-policy"
 
@@ -13,37 +12,34 @@ export class UsersPolicy extends BasePolicy<User> {
   }
 
   create(): boolean {
-    if (this.user.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)) return true
+    if (this.user.isSystemAdmin) return true
 
     return false
   }
 
   update(): boolean {
-    if (this.user.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)) return true
+    if (this.user.isSystemAdmin) return true
     if (this.user.id === this.record.id) return true
 
     return false
   }
 
   destroy(): boolean {
-    if (this.user.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)) return true
+    if (this.user.isSystemAdmin) return true
 
     return false
   }
 
   permittedAttributes(): Path[] {
-    if (this.user.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)) {
-      return [
-        "email",
-        "firstName",
-        "lastName",
-        "position",
-        {
-          groupMembershipAttributes: ["departmentId", "divisionId", "branchId", "unitId"],
-        },
-      ]
+    const attributes: Path[] = ["email", "firstName", "lastName", "position"]
+
+    if (this.user.isSystemAdmin) {
+      attributes.push({
+        groupMembershipAttributes: ["departmentId", "divisionId", "branchId", "unitId"],
+      })
     }
-    return ["email", "firstName", "lastName"]
+
+    return attributes
   }
 
   permittedAttributesForCreate(): Path[] {

--- a/api/src/policies/users-policy.ts
+++ b/api/src/policies/users-policy.ts
@@ -32,15 +32,18 @@ export class UsersPolicy extends BasePolicy<User> {
   }
 
   permittedAttributes(): Path[] {
-    return [
-      "email",
-      "firstName",
-      "lastName",
-      "position",
-      {
-        groupMembershipAttributes: ["departmentId", "divisionId", "branchId", "unitId"],
-      },
-    ]
+    if (this.user.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)) {
+      return [
+        "email",
+        "firstName",
+        "lastName",
+        "position",
+        {
+          groupMembershipAttributes: ["departmentId", "divisionId", "branchId", "unitId"],
+        },
+      ]
+    }
+    return ["email", "firstName", "lastName"]
   }
 
   permittedAttributesForCreate(): Path[] {

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -115,6 +115,7 @@ services:
 
   mail:
     image: maildev/maildev
+    user: root
     ports:
       - "1080:1080" # Web UI
       - "1025:1025" # SMTP
@@ -122,12 +123,12 @@ services:
   # For easily generating large PlantUML diagrams
   # Not relevant to production environment.
   # Accessible at http://localhost:9999
-  plantuml:
-    image: plantuml/plantuml-server:jetty
-    ports:
-      - 9999:8080
-    environment:
-      PLANTUML_LIMIT_SIZE: 8192
+  # plantuml:
+  #   image: plantuml/plantuml-server:jetty
+  #   ports:
+  #     - 9999:8080
+  #   environment:
+  #     PLANTUML_LIMIT_SIZE: 8192
 
 volumes:
   db_data:

--- a/web/src/components/users/AdminUserEditForm.vue
+++ b/web/src/components/users/AdminUserEditForm.vue
@@ -91,7 +91,6 @@
           clearable
           :readonly="isNil(groupMembershipAttributes.departmentId)"
           :disabled="isNil(groupMembershipAttributes.departmentId)"
-          :append-inner-icon="isNil(groupMembershipAttributes.departmentId) ? 'mdi-lock' : ''"
           @update:model-value="updateDivision"
         />
       </v-col>
@@ -111,7 +110,6 @@
           clearable
           :readonly="isNil(groupMembershipAttributes.divisionId)"
           :disabled="isNil(groupMembershipAttributes.divisionId)"
-          :append-inner-icon="isNil(groupMembershipAttributes.divisionId) ? 'mdi-lock' : ''"
           @update:model-value="updateBranch"
         />
       </v-col>
@@ -128,7 +126,6 @@
           clearable
           :readonly="isNil(groupMembershipAttributes.branchId)"
           :disabled="isNil(groupMembershipAttributes.branchId)"
-          :append-inner-icon="isNil(groupMembershipAttributes.branchId) ? 'mdi-lock' : ''"
           @update:model-value="updateUnit"
         />
       </v-col>

--- a/web/src/components/users/AdminUserEditForm.vue
+++ b/web/src/components/users/AdminUserEditForm.vue
@@ -90,6 +90,7 @@
           variant="outlined"
           clearable
           :readonly="isNil(groupMembershipAttributes.departmentId)"
+          :disabled="isNil(groupMembershipAttributes.departmentId)"
           :append-inner-icon="isNil(groupMembershipAttributes.departmentId) ? 'mdi-lock' : ''"
           @update:model-value="updateDivision"
         />
@@ -109,6 +110,7 @@
           variant="outlined"
           clearable
           :readonly="isNil(groupMembershipAttributes.divisionId)"
+          :disabled="isNil(groupMembershipAttributes.divisionId)"
           :append-inner-icon="isNil(groupMembershipAttributes.divisionId) ? 'mdi-lock' : ''"
           @update:model-value="updateBranch"
         />
@@ -125,6 +127,7 @@
           variant="outlined"
           clearable
           :readonly="isNil(groupMembershipAttributes.branchId)"
+          :disabled="isNil(groupMembershipAttributes.branchId)"
           :append-inner-icon="isNil(groupMembershipAttributes.branchId) ? 'mdi-lock' : ''"
           @update:model-value="updateUnit"
         />

--- a/web/src/components/users/AdminUserEditForm.vue
+++ b/web/src/components/users/AdminUserEditForm.vue
@@ -5,7 +5,7 @@
   />
   <v-form
     v-else
-    v-model="isValid"
+    ref="formRef"
     @submit.prevent="saveWrapper"
   >
     <v-row>
@@ -176,7 +176,7 @@
 import { isNil } from "lodash"
 import { ref, toRefs, watch } from "vue"
 import { useI18n } from "vue-i18n"
-import { VBtn } from "vuetify/lib/components/index.mjs"
+import { VBtn, VForm } from "vuetify/lib/components/index.mjs"
 
 import { required } from "@/utils/validators"
 
@@ -211,11 +211,15 @@ const { user, save, isLoading } = useUser(userId)
 
 const snack = useSnack()
 
-const isValid = ref(false)
 const groupMembershipAttributes = ref<Partial<GroupMembership>>({})
 
+const formRef = ref<InstanceType<typeof VForm> | null>(null)
+
 async function saveWrapper() {
-  if (!isValid.value) {
+  if (formRef.value === null) return
+
+  const { valid } = await formRef.value.validate()
+  if (!valid) {
     snack.notify("Please fill out all required fields", { color: "error" })
     return
   }

--- a/web/src/components/users/AdminUserEditForm.vue
+++ b/web/src/components/users/AdminUserEditForm.vue
@@ -75,8 +75,6 @@
           label="Department"
           variant="outlined"
           required
-          readonly
-          append-inner-icon="mdi-lock"
           @update:model-value="updateDepartment"
         />
       </v-col>
@@ -91,8 +89,8 @@
           label="Division"
           variant="outlined"
           clearable
-          readonly
-          append-inner-icon="mdi-lock"
+          :readonly="isNil(groupMembershipAttributes.departmentId)"
+          :append-inner-icon="isNil(groupMembershipAttributes.departmentId) ? 'mdi-lock' : ''"
           @update:model-value="updateDivision"
         />
       </v-col>
@@ -110,8 +108,8 @@
           label="Branch"
           variant="outlined"
           clearable
-          readonly
-          append-inner-icon="mdi-lock"
+          :readonly="isNil(groupMembershipAttributes.divisionId)"
+          :append-inner-icon="isNil(groupMembershipAttributes.divisionId) ? 'mdi-lock' : ''"
           @update:model-value="updateBranch"
         />
       </v-col>
@@ -126,8 +124,8 @@
           label="Unit"
           variant="outlined"
           clearable
-          readonly
-          append-inner-icon="mdi-lock"
+          :readonly="isNil(groupMembershipAttributes.branchId)"
+          :append-inner-icon="isNil(groupMembershipAttributes.branchId) ? 'mdi-lock' : ''"
           @update:model-value="updateUnit"
         />
       </v-col>

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -76,6 +76,7 @@
           variant="outlined"
           required
           readonly
+          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateDepartment"
         />
@@ -92,6 +93,7 @@
           variant="outlined"
           clearable
           readonly
+          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateDivision"
         />
@@ -111,6 +113,7 @@
           variant="outlined"
           clearable
           readonly
+          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateBranch"
         />
@@ -127,6 +130,7 @@
           variant="outlined"
           clearable
           readonly
+          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateUnit"
         />

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -176,17 +176,17 @@
 import { isNil } from "lodash"
 import { ref, toRefs, watch } from "vue"
 import { useI18n } from "vue-i18n"
-
 import { VBtn } from "vuetify/lib/components/index.mjs"
 
-import { GroupMembership } from "@/api/users-api"
 import { required } from "@/utils/validators"
+
+import { GroupMembership } from "@/api/users-api"
 import { UserGroupTypes } from "@/api/user-groups-api"
 import useSnack from "@/use/use-snack"
 import useUser from "@/use/use-user"
+import useCurrentUser from "@/use/use-current-user"
 
 import UserGroupAutocomplete from "@/components/user-groups/UserGroupAutocomplete.vue"
-import useCurrentUser from "@/use/use-current-user"
 
 type CancelButtonOptions = VBtn["$props"]
 

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -71,11 +71,12 @@
           :model-value="groupMembershipAttributes.departmentId"
           :type="UserGroupTypes.DEPARTMENT"
           :parent-id="null"
-          :disabled="!isSystemAdmin"
           :rules="[required]"
           label="Department"
           variant="outlined"
           required
+          :readonly="!isSystemAdmin"
+          :append-inner-icon="!isSystemAdmin ? 'mdi-lock' : ''"
           @update:model-value="updateDepartment"
         />
       </v-col>
@@ -87,10 +88,13 @@
           :model-value="groupMembershipAttributes.divisionId"
           :type="UserGroupTypes.DIVISION"
           :parent-id="groupMembershipAttributes.departmentId"
-          :disabled="isNil(groupMembershipAttributes.departmentId) || !isSystemAdmin"
           label="Division"
           variant="outlined"
           clearable
+          :readonly="!isSystemAdmin || isNil(groupMembershipAttributes.departmentId)"
+          :append-inner-icon="
+            !isSystemAdmin || isNil(groupMembershipAttributes.departmentId) ? 'mdi-lock' : ''
+          "
           @update:model-value="updateDivision"
         />
       </v-col>
@@ -105,10 +109,13 @@
           :model-value="groupMembershipAttributes.branchId"
           :type="UserGroupTypes.BRANCH"
           :parent-id="groupMembershipAttributes.divisionId"
-          :disabled="isNil(groupMembershipAttributes.divisionId) || !isSystemAdmin"
           label="Branch"
           variant="outlined"
           clearable
+          :readonly="!isSystemAdmin || isNil(groupMembershipAttributes.divisionId)"
+          :append-inner-icon="
+            !isSystemAdmin || isNil(groupMembershipAttributes.divisionId) ? 'mdi-lock' : ''
+          "
           @update:model-value="updateBranch"
         />
       </v-col>
@@ -120,10 +127,13 @@
           :model-value="groupMembershipAttributes.unitId"
           :type="UserGroupTypes.UNIT"
           :parent-id="groupMembershipAttributes.branchId"
-          :disabled="isNil(groupMembershipAttributes.branchId) || !isSystemAdmin"
           label="Unit"
           variant="outlined"
           clearable
+          :readonly="!isSystemAdmin || isNil(groupMembershipAttributes.branchId)"
+          :append-inner-icon="
+            !isSystemAdmin || isNil(groupMembershipAttributes.branchId) ? 'mdi-lock' : ''
+          "
           @update:model-value="updateUnit"
         />
       </v-col>

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -71,6 +71,7 @@
           :model-value="groupMembershipAttributes.departmentId"
           :type="UserGroupTypes.DEPARTMENT"
           :parent-id="null"
+          :disabled="!isSystemAdmin"
           :rules="[required]"
           label="Department"
           variant="outlined"
@@ -86,7 +87,7 @@
           :model-value="groupMembershipAttributes.divisionId"
           :type="UserGroupTypes.DIVISION"
           :parent-id="groupMembershipAttributes.departmentId"
-          :disabled="isNil(groupMembershipAttributes.departmentId)"
+          :disabled="isNil(groupMembershipAttributes.departmentId) || !isSystemAdmin"
           label="Division"
           variant="outlined"
           clearable
@@ -104,7 +105,7 @@
           :model-value="groupMembershipAttributes.branchId"
           :type="UserGroupTypes.BRANCH"
           :parent-id="groupMembershipAttributes.divisionId"
-          :disabled="isNil(groupMembershipAttributes.divisionId)"
+          :disabled="isNil(groupMembershipAttributes.divisionId) || !isSystemAdmin"
           label="Branch"
           variant="outlined"
           clearable
@@ -119,7 +120,7 @@
           :model-value="groupMembershipAttributes.unitId"
           :type="UserGroupTypes.UNIT"
           :parent-id="groupMembershipAttributes.branchId"
-          :disabled="isNil(groupMembershipAttributes.branchId)"
+          :disabled="isNil(groupMembershipAttributes.branchId) || !isSystemAdmin"
           label="Unit"
           variant="outlined"
           clearable
@@ -206,7 +207,7 @@ const props = withDefaults(
 const emit = defineEmits(["saved"])
 
 const { userId } = toRefs(props)
-const { user, save, isLoading } = useUser(userId)
+const { user, isSystemAdmin, save, isLoading } = useUser(userId)
 
 const snack = useSnack()
 

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -76,7 +76,6 @@
           variant="outlined"
           required
           readonly
-          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateDepartment"
         />
@@ -93,7 +92,6 @@
           variant="outlined"
           clearable
           readonly
-          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateDivision"
         />
@@ -113,7 +111,6 @@
           variant="outlined"
           clearable
           readonly
-          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateBranch"
         />
@@ -130,7 +127,6 @@
           variant="outlined"
           clearable
           readonly
-          disabled
           append-inner-icon="mdi-lock"
           @update:model-value="updateUnit"
         />

--- a/web/src/components/users/UserEditForm.vue
+++ b/web/src/components/users/UserEditForm.vue
@@ -186,6 +186,7 @@ import useSnack from "@/use/use-snack"
 import useUser from "@/use/use-user"
 
 import UserGroupAutocomplete from "@/components/user-groups/UserGroupAutocomplete.vue"
+import useCurrentUser from "@/use/use-current-user"
 
 type CancelButtonOptions = VBtn["$props"]
 
@@ -207,7 +208,8 @@ const props = withDefaults(
 const emit = defineEmits(["saved"])
 
 const { userId } = toRefs(props)
-const { user, isSystemAdmin, save, isLoading } = useUser(userId)
+const { user, save, isLoading } = useUser(userId)
+const { isSystemAdmin } = useCurrentUser()
 
 const snack = useSnack()
 

--- a/web/src/pages/ProfileEditPage.vue
+++ b/web/src/pages/ProfileEditPage.vue
@@ -24,7 +24,15 @@
       </div>
     </h2>
 
+    <AdminUserEditForm
+      v-if="isSystemAdmin"
+      class="mt-10"
+      :user-id="currentUser.id"
+      :cancel-button-options="{ to: { name: 'ProfilePage' } }"
+      @saved="refresh"
+    />
     <UserEditForm
+      v-else
       class="mt-10"
       :user-id="currentUser.id"
       :cancel-button-options="{ to: { name: 'ProfilePage' } }"
@@ -39,9 +47,10 @@ import { isNil } from "lodash"
 import useBreadcrumbs from "@/use/use-breadcrumbs"
 import useCurrentUser from "@/use/use-current-user"
 
+import AdminUserEditForm from "@/components/users/AdminUserEditForm.vue"
 import UserEditForm from "@/components/users/UserEditForm.vue"
 
-const { currentUser, sync, refresh } = useCurrentUser()
+const { currentUser, isSystemAdmin, sync, refresh } = useCurrentUser()
 
 const { setBreadcrumbs } = useBreadcrumbs()
 

--- a/web/src/pages/UserEditPage.vue
+++ b/web/src/pages/UserEditPage.vue
@@ -29,7 +29,15 @@
       </div>
     </h2>
 
+    <AdminUserEditForm
+      v-if="isSystemAdmin"
+      class="mt-10"
+      :user-id="user.id"
+      :cancel-button-options="{ to: { name: 'UsersPage' } }"
+      @saved="refresh"
+    />
     <UserEditForm
+      v-else
       class="mt-10"
       :user-id="user.id"
       :cancel-button-options="{ to: { name: 'UsersPage' } }"
@@ -44,7 +52,9 @@ import { isNil } from "lodash"
 
 import useBreadcrumbs from "@/use/use-breadcrumbs"
 import useUser from "@/use/use-user"
+import useCurrentUser from "@/use/use-current-user"
 
+import AdminUserEditForm from "@/components/users/AdminUserEditForm.vue"
 import UserEditForm from "@/components/users/UserEditForm.vue"
 
 const props = defineProps<{
@@ -53,6 +63,7 @@ const props = defineProps<{
 
 const userId = computed(() => parseInt(props.userId))
 const { user, sync, refresh } = useUser(userId)
+const { isSystemAdmin } = useCurrentUser()
 
 const username = computed(() => {
   if (user.value === null) return "loading..."

--- a/web/src/pages/UserEditPage.vue
+++ b/web/src/pages/UserEditPage.vue
@@ -30,14 +30,6 @@
     </h2>
 
     <AdminUserEditForm
-      v-if="isSystemAdmin"
-      class="mt-10"
-      :user-id="user.id"
-      :cancel-button-options="{ to: { name: 'UsersPage' } }"
-      @saved="refresh"
-    />
-    <UserEditForm
-      v-else
       class="mt-10"
       :user-id="user.id"
       :cancel-button-options="{ to: { name: 'UsersPage' } }"
@@ -52,10 +44,8 @@ import { isNil } from "lodash"
 
 import useBreadcrumbs from "@/use/use-breadcrumbs"
 import useUser from "@/use/use-user"
-import useCurrentUser from "@/use/use-current-user"
 
 import AdminUserEditForm from "@/components/users/AdminUserEditForm.vue"
-import UserEditForm from "@/components/users/UserEditForm.vue"
 
 const props = defineProps<{
   userId: string
@@ -63,7 +53,6 @@ const props = defineProps<{
 
 const userId = computed(() => parseInt(props.userId))
 const { user, sync, refresh } = useUser(userId)
-const { isSystemAdmin } = useCurrentUser()
 
 const username = computed(() => {
   if (user.value === null) return "loading..."

--- a/web/src/use/use-current-user.ts
+++ b/web/src/use/use-current-user.ts
@@ -22,6 +22,10 @@ const state = reactive<{
 export function useCurrentUser() {
   const isReady = computed(() => !state.isLoading && !state.isErrored)
 
+  const isSystemAdmin = computed(
+    () => state.currentUser?.roles?.some(({ role }) => role === RoleTypes.SYSTEM_ADMIN)
+  )
+
   async function fetch(): Promise<User> {
     state.isLoading = true
     try {
@@ -88,6 +92,7 @@ export function useCurrentUser() {
   return {
     ...toRefs(state),
     isReady,
+    isSystemAdmin,
     fetch,
     refresh: fetch,
     ensure,

--- a/web/src/use/use-current-user.ts
+++ b/web/src/use/use-current-user.ts
@@ -23,7 +23,7 @@ export function useCurrentUser() {
   const isReady = computed(() => !state.isLoading && !state.isErrored)
 
   const isSystemAdmin = computed(
-    () => state.currentUser?.roles?.some(({ role }) => role === RoleTypes.SYSTEM_ADMIN)
+    () => state.currentUser?.roleTypes.includes(RoleTypes.SYSTEM_ADMIN)
   )
 
   async function fetch(): Promise<User> {

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -1,7 +1,7 @@
-import { type Ref, reactive, unref, watch, toRefs } from "vue"
+import { type Ref, reactive, unref, watch, toRefs, computed } from "vue"
 import { isNil } from "lodash"
 
-import usersApi, { type User, type UserUpdate } from "@/api/users-api"
+import usersApi, { RoleTypes, type User, type UserUpdate } from "@/api/users-api"
 
 export { type User, type UserUpdate }
 
@@ -24,6 +24,10 @@ export function useUser(
     isLoading: false,
     isErrored: false,
   })
+
+  const isSystemAdmin = computed(
+    () => state.user?.roles?.some(({ role }) => role === RoleTypes.SYSTEM_ADMIN)
+  )
 
   async function fetch() {
     const staticId = unref(id)
@@ -118,6 +122,7 @@ export function useUser(
 
   return {
     ...toRefs(state),
+    isSystemAdmin,
     fetch,
     refresh: fetch,
     save,

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -3,7 +3,7 @@ import { isNil } from "lodash"
 
 import usersApi, { RoleTypes, type User, type UserUpdate } from "@/api/users-api"
 
-export { type User, type UserUpdate }
+export { RoleTypes, type User, type UserUpdate }
 
 export function useUser(
   id: Ref<number | null | undefined>,

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -1,9 +1,9 @@
 import { type Ref, reactive, unref, watch, toRefs } from "vue"
 import { isNil } from "lodash"
 
-import usersApi, { RoleTypes, type User, type UserUpdate } from "@/api/users-api"
+import usersApi, { type RoleTypes, type User, type UserUpdate } from "@/api/users-api"
 
-export { RoleTypes, type User, type UserUpdate }
+export { type RoleTypes, type User, type UserUpdate }
 
 export function useUser(
   id: Ref<number | null | undefined>,

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -25,9 +25,7 @@ export function useUser(
     isErrored: false,
   })
 
-  const isSystemAdmin = computed(
-    () => state.user?.roles?.some(({ role }) => role === RoleTypes.SYSTEM_ADMIN)
-  )
+  const isSystemAdmin = computed(() => state.user?.roleTypes.includes(RoleTypes.SYSTEM_ADMIN))
 
   async function fetch() {
     const staticId = unref(id)

--- a/web/src/use/use-user.ts
+++ b/web/src/use/use-user.ts
@@ -1,4 +1,4 @@
-import { type Ref, reactive, unref, watch, toRefs, computed } from "vue"
+import { type Ref, reactive, unref, watch, toRefs } from "vue"
 import { isNil } from "lodash"
 
 import usersApi, { RoleTypes, type User, type UserUpdate } from "@/api/users-api"
@@ -24,8 +24,6 @@ export function useUser(
     isLoading: false,
     isErrored: false,
   })
-
-  const isSystemAdmin = computed(() => state.user?.roleTypes.includes(RoleTypes.SYSTEM_ADMIN))
 
   async function fetch() {
     const staticId = unref(id)
@@ -120,7 +118,6 @@ export function useUser(
 
   return {
     ...toRefs(state),
-    isSystemAdmin,
     fetch,
     refresh: fetch,
     save,


### PR DESCRIPTION
resolves #106 

## Implementation

- If current user is a System admin then that user gets a user edit page with all 8 fields, otherwise servered a different form that is more restrictive
- At the user api endpoint, the user controller uses the user policy to check if the user if an admin. 

## Screenshots

![idp111](https://github.com/user-attachments/assets/01947a9a-ccd7-46b5-a844-22aa6682cdc0)
***figure 1** profile/edit as a regular user*

![admin](https://github.com/user-attachments/assets/0a327261-c3e6-40d4-9aa5-e58c99e2b6f6)
***figure 2** profile/edit as a system_admin*

## Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080 (as non `system_admin`)
4. Go to http://localhost:8080/profile/edit
5. Ensure certain fields are locked
6. Go back to http://localhost:8080/profile/edit as `system_admin`
8. Ensure you can now alter certain fields
