### PR TITLE
Fix for db healthcheck with old mssql version

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 x-default-environment: &default-environment
   TZ: "UTC"
   NODE_ENV: development

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -87,7 +87,7 @@ services:
       - ./web:/usr/src/web
 
   db:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
     user: root
     environment:
       <<: *default-environment


### PR DESCRIPTION
Fixes #117 

## Context
The health check in the `docker-compose.development.yml` will fail due to new changes to `mcr.microsoft.com/mssql/server`

## Implementation
- Use mssql version 2022-CU13-ubuntu-22.04 to keep healthcheck working
- Removed docker-compose version as its obsolete (https://docs.docker.com/reference/compose-file/version-and-name/)

## Testing Instructions
1. Remove any docker images and/or containers associated with `internal-data-portal-db-1`
2. Run `dev up`
3. Should build as normal