### PR TITLE
Issue 121: Unable To Create User Second User

### DIFF
--- a/api/src/db/migrations/2025.05.14T18.16.53.update-auth0-subject-uniquness-to-permit-nulls.ts
+++ b/api/src/db/migrations/2025.05.14T18.16.53.update-auth0-subject-uniquness-to-permit-nulls.ts
@@ -1,0 +1,31 @@
+import { Op } from "sequelize"
+import type { Migration } from "@/db/umzug"
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeIndex("users", "unique_users_auth0_subject")
+
+  await queryInterface.addIndex("users", {
+    name: "unique_users_auth0_subject",
+    unique: true,
+    fields: ["auth0_subject"],
+    where: {
+      auth0_subject: {
+        [Op.not]: null,
+      },
+      deleted_at: null,
+    },
+  })
+}
+
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeIndex("users", "unique_users_auth0_subject")
+
+  await queryInterface.addIndex("users", {
+    name: "unique_users_auth0_subject",
+    unique: true,
+    fields: ["auth0_subject"],
+    where: {
+      deleted_at: null,
+    },
+  })
+}

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -292,6 +292,9 @@ User.init(
         fields: ["auth0_subject"],
         name: "unique_users_auth0_subject",
         where: {
+          auth0_subject: {
+            [Op.not]: null,
+          },
           deleted_at: null,
         },
       },


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/internal-data-portal/issues/121

# Context

**Describe the bug**
When attempting to add a new second user to the Internal Data Portal (IDP), the creation fails with a `Failed to create` error message.

**To Reproduce**
Steps to reproduce the behavior:
1. Log in as a system admin role user.
2. Select "All Users" from the top right kebab menu.
3. Click the "Create User" button in the top right of the table.
4. Fill in user details.
3. Click Create.
4. Create a second user.

**Expected behavior**
Second user should create successfully.

**Screenshots**

![Image](https://github.com/user-attachments/assets/492c0e5c-80ea-4b55-a4be-e2b2db67ecd1)

**Additional context**
Issue related to the unique constraint on the auth0_subject field.
Newly created users have `null` Auth0 subject, and the unique constraint only permitted one of these.
Cause: bad AI info, ChatGPT is convinced that nulls don't need to be referenced in the index for MSSQL. This is incorrect. They need to be explicitly excluded to have the index perform as expected here. Correct solution found at https://stackoverflow.com/questions/191421/how-to-create-a-unique-index-on-a-null-column

# Implementation

Update users auth0_subject unique index to exclude nulls from check.

# Testing Instructions

1. Run the test suite via `dev test` (or `dev test_api`)
2. Boot the app via `dev up`
3. Log in to the app at http://localhost:8080 as a system admin role user.
2. Select "All Users" from the top right kebab menu.
3. Click the "Create User" button in the top right of the table.
4. Fill in user details.
3. Click Create.
4. Create a second user.
